### PR TITLE
Configure system testing env

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,3 +7,45 @@ Capybara.default_max_wait_time = 2
 Capybara.default_normalize_ws = true
 
 Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      args: [
+        "allow-insecure-localhost",
+      ],
+      w3c: false
+    }
+  )
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+Capybara.register_driver :chrome_headless do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      args: [
+        "headless",
+        "disable-gpu",
+        "allow-insecure-localhost",
+      ],
+      w3c: false
+    }
+  )
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+
+  config.before(:each, type: :system, js: true, headless: false) do
+    driven_by :chrome
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,1 @@
+RSpec.configure { |config| config.include FactoryBot::Syntax::Methods }

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,4 @@
 require "webmock/rspec"
 
-WebMock.disable_net_connect! allow_localhost: true
+allowed_hosts = ["chromedriver.storage.googleapis.com"]
+WebMock.disable_net_connect! allow_localhost: true, allowed: allowed_hosts


### PR DESCRIPTION
This configures the system tests Capybara drivers.

By default, it will run on Rack Test.

If running JS is needed in a system spec, then there are two options:

1) set `js: true` on the test - this will run Chrome in headless mode
2) set `js: true, headless: false` on the test - this will launch Chrome
   in GUI mode