### PR TITLE
Correct webmock config typo

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,4 +1,4 @@
 require "webmock/rspec"
 
 allowed_hosts = ["chromedriver.storage.googleapis.com"]
-WebMock.disable_net_connect! allow_localhost: true, allowed: allowed_hosts
+WebMock.disable_net_connect! allow_localhost: true, allow: allowed_hosts


### PR DESCRIPTION
We had a typo in the Webmock config - the key for allowing hosts is
`allow` not `allowed`.

This corrects the config to act properly