### PR TITLE
Add Procfiles

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -p $PORT -C ./config/puma.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+app: bin/rails server
+assets: bin/webpack-dev-server

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,14 +25,14 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
This adds a staging/production Procfile as well as a development
Procfile (Procfile.dev).

For development, this allows starting the application with `foreman
start -f Procfile.dev`, which will boot the rails server and the webpack
server.

You can also boot the application in development with `heroku local -f
Procfile.dev` to enjoy the same benefits.

For the former, the `foreman` gem should be installed in the dev machine
and for the latter, the Heroku CLI tool should be installed.

This also adjust the puma config to run with Workers and preloading the
app.