### PR TITLE
Add get_started page

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -4,7 +4,26 @@ class SurveysController < ApplicationController
   # GET /surveys
   # GET /surveys.json
   def index
-    @building = Building.last
-    @survey = Survey.create building: @building
+    if params.has_key?(:uprn)
+      @building = Building.find_by(uprn: params[:uprn])
+      @survey = Survey.create building: @building
+    end
+  end
+
+  def new
+    @building = Building.new
+    @survey = Survey.new building: @building
+  end
+
+  def create
+    @building = Building.find_by(uprn: params[:survey][:uprn])
+    @survey = Survey.new building: @building
+    if @survey.save
+      redirect_to new_survey_building_status_path(@survey)
+    else
+      respond_to do |format|
+        format.html { render :new  }
+      end
+    end
   end
 end

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -19,11 +19,20 @@
           <li>Details and materials of external structures eg. balconies</li>
         </ul>
         <p class="govuk-body">To start the form or to tell us if this information is not correct click the following link.</p>
-        <%= link_to new_survey_building_status_path(@survey), role: "button", draggable: false, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", data: { module: "govuk-button" } do %>
-          Start now
-          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-          </svg>
+        <% if params.has_key?(:uprn) %>
+          <%= link_to new_survey_building_status_path(@survey), role: "button", draggable: false, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", data: { module: "govuk-button" } do %>
+            Start now
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+          <% end %>
+        <% else %>
+          <%= link_to get_started_path, role: "button", draggable: false, class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start", data: { module: "govuk-button" } do %>
+            Start now
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+          <% end %>
         <% end %>
         <h2 class="govuk-heading-m">Asking someone else to fill in the building safety survey on your behalf</h2>
         <p class="govuk-body">A colleague can complete this survey on your behalf if they have the information listed above.</p>
@@ -33,7 +42,7 @@
         <p class="govuk-body">Once data has been collected on these buildings, the risks will be better known. The Ministry of Housing, Communities & Local Government</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-s">Related content</h2>
+        <h2 class="govuk-heading-m">Related content</h2>
         <p class="govuk-body"><%= link_to "Building safety advice", "https://www.gov.uk/government/publications/building-safety-advice-for-building-owners-including-fire-doors" %></p>
         <p class="govuk-body">Remediation measures / funding options</p>
         <p class="govuk-body">Data usage</p>

--- a/app/views/surveys/new.html.erb
+++ b/app/views/surveys/new.html.erb
@@ -1,0 +1,19 @@
+<%= render 'application/back_link', chosen_path: root_path %>
+<%= form_with model: @survey, local: true do |form| %>
+<h1 class="govuk-heading-xl">Get started</h1>
+  <% if @survey.errors.any? %>
+    <div class="govuk-error-summary">
+      <h2 class="govuk-error-summary__title">There was a problem with code input</h2>
+      <div class="govuk-error-summary__body">
+        <ul>
+            <li>Please enter the correct code</li>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+  <div class="govuk-form-group <%= " govuk-form-group--error" if @survey.errors.any? %>">
+    <p class="govuk-body-l">To complete the survey you need to find the correct building. Please enter the code included in the notification of this survey:</p>
+    <%= form.text_field :uprn, class: "govuk-input govuk-input--width-20" %>
+  </div>
+  <%= form.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root to: "surveys#index"
 
   get "new_survey", to: "surveys/start_surveys#new", as: :start_new_survey
+  get "get_started", to: "surveys#new", as: :get_started
 
   resources :surveys do
     resources :building_statuses, controller: "surveys/building_statuses"

--- a/db/migrate/20200908110121_change_column_name.rb
+++ b/db/migrate/20200908110121_change_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeColumnName < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :buildings, :UPRN, :uprn
+  end
+end

--- a/db/migrate/20200908131842_change_uprn_to_be_string_in_buildings.rb
+++ b/db/migrate/20200908131842_change_uprn_to_be_string_in_buildings.rb
@@ -1,0 +1,5 @@
+class ChangeUprnToBeStringInBuildings < ActiveRecord::Migration[6.0]
+  def change
+    change_column :buildings, :uprn, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_163743) do
+ActiveRecord::Schema.define(version: 2020_09_08_131842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_163743) do
 
   create_table "buildings", force: :cascade do |t|
     t.string "address", null: false
-    t.bigint "UPRN"
+    t.string "uprn"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "manager_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,5 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 building_manager = BuildingManager.find_or_create_by(email: "example@example.com")
-building = Building.find_or_create_by(address: "134 Test Row, London", UPRN: 20012524507, manager: building_manager)
+building = Building.find_or_create_by(address: "134 Test Row, London", uprn: "20012524507", manager: building_manager)
 survey = Survey.find_or_create_by(building_id: building.id)

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     association :manager, factory: :building_manager
 
     address { "A place full of wonders" }
-    UPRN { rand 10**12 }
+    uprn { SecureRandom.alphanumeric }
   end
 end

--- a/spec/features/building_manager_journey_spec.rb
+++ b/spec/features/building_manager_journey_spec.rb
@@ -17,11 +17,16 @@ RSpec.describe "Building manager functionality" do
       expect(page).to have_text("Building safety survey")
 
       click_on "Start now"
-      expect(page).to have_text("Please confirm the status of this building")
+      expect(page).to have_text("Get started")
     end
 
     it "allows a building manager to fill in the complete building information" do
       click_link "Start now"
+
+      fill_in with: building.uprn
+      click_button "Continue"
+      expect(page).to have_text("Please confirm the status of this building")
+
       choose "Existing", visible: false
       click_button "Continue"
       expect(page).to have_text("Please indicate the building use")

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Building manager views survey reply summary" do
     before do
       visit root_path
       click_on "Start now"
+      fill_in with: building.uprn
+      click_button "Continue"
     end
 
     it "allows managers to modify building status" do
@@ -110,7 +112,17 @@ RSpec.describe "Building manager views survey reply summary" do
       click_on "Start now"
     end
 
+    it "displays an error if uprn is incorrect" do
+      fill_in with: 123
+      click_button "Continue"
+
+      expect(page).to have_text "There was a problem with code input"
+      expect(page).to have_text "Please enter the correct code"
+    end
+
     it "displays an error if building_status not selected" do
+      fill_in with: building.uprn
+      click_button "Continue"
       click_on "Continue"
 
       expect(page).to have_text "There was a problem with your survey"
@@ -118,6 +130,8 @@ RSpec.describe "Building manager views survey reply summary" do
     end
 
     it "displays an error if building_tenure not selected" do
+      fill_in with: building.uprn
+      click_button "Continue"
       choose "Existing", visible: false
       click_on "Continue"
       click_on "Continue"


### PR DESCRIPTION
# * Why was this change necessary? 
As a building owner i should be able to fill in the survey even if I didn't receive and email with uniq link, but I received  a letter with my UPRN code 
# * How does it address the problem?
Now if link doesn't have UPRN in it, user will be redirected to get started page, where they can enter UPRN code, app will find their building in the db and will start a new survey related to that building
# * Are there any side effects?
no
#
# Include a link to the ticket, if any.
https://trello.com/c/A4gnYX4n/100-as-a-building-owner-i-want-to-see-a-get-started-page-where-i-can-enter-the-uprn-unique-building-code-on-clicking-continue-a-look
#