### PR TITLE
Implement logic to sessions when on edit

### DIFF
--- a/app/controllers/concerns/survey_routable.rb
+++ b/app/controllers/concerns/survey_routable.rb
@@ -1,7 +1,11 @@
 module SurveyRoutable
   extend ActiveSupport::Concern
 
-  def next_survey_section(current_section:, survey:)
-    SurveySequenceRouter.for(survey).next_section_for(current_section.content)
+  def next_survey_section(current_section:, survey:, next_section:)
+    SurveySequenceRouter.for(survey).next_section_for(current_section.content, next_section)
+  end
+
+  def section(survey, section)
+    survey.sections.find_by(content_type: section)
   end
 end

--- a/app/controllers/surveys/building_external_wall_structures_controller.rb
+++ b/app/controllers/surveys/building_external_wall_structures_controller.rb
@@ -4,7 +4,7 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingWall")
       @building_external_wall_structure = BuildingExternalWallStructure.new survey: @survey
     end
 
@@ -12,7 +12,8 @@ module Surveys
       @building_external_wall_structure = BuildingExternalWallStructure.new(external_structure_params)
       if @building_external_wall_structure.save
         survey.sections.create content: @building_external_wall_structure
-        redirect_to next_survey_section(current_section: @building_external_wall_structure.section, survey: survey)
+        next_section = "summary"
+        redirect_to next_survey_section(current_section: @building_external_wall_structure.section, survey: survey, next_section: next_section)
       else
         respond_to do |format|
           @survey = survey
@@ -24,14 +25,15 @@ module Surveys
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingWall")
       @building_external_wall_structure = building_external_wall_structure
     end
 
     def update
       @building_external_wall_structure = building_external_wall_structure
       if @building_external_wall_structure.update external_structure_params
-        redirect_to next_survey_section(current_section: @building_external_wall_structure.section, survey: survey)
+        next_section = "summary"
+        redirect_to next_survey_section(current_section: @building_external_wall_structure.section, survey: survey, next_section: next_section)
       else
         respond_to do |format|
           @survey = survey
@@ -44,10 +46,6 @@ module Surveys
 
       def survey
         Survey.find params[:survey_id]
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingWall")
       end
 
       def building_external_wall_structure

--- a/app/controllers/surveys/building_heights_controller.rb
+++ b/app/controllers/surveys/building_heights_controller.rb
@@ -4,7 +4,7 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingOwnership")
       @building_height = BuildingHeight.new(survey: @survey)
     end
 
@@ -12,14 +12,15 @@ module Surveys
       building_height = survey.sections.build content: BuildingHeight.new(building_height_params)
 
       if building_height.save
-        redirect_to next_survey_section(current_section: building_height, survey: survey)
+        next_section = section(survey, "BuildingWall")
+        redirect_to next_survey_section(current_section: building_height, survey: survey, next_section: next_section)
       end
     end
 
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingOwnership")
       @building_height = building_height
     end
 
@@ -28,7 +29,8 @@ module Surveys
         if session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
         else
-          redirect_to next_survey_section(current_section: building_height.section, survey: survey)
+          next_section = section(survey, "BuildingWall")
+          redirect_to next_survey_section(current_section: building_height.section, survey: survey, next_section: next_section)
         end
       end
     end
@@ -37,10 +39,6 @@ module Surveys
 
       def survey
         Survey.find params[:survey_id]
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingOwnership")
       end
 
       def building_height

--- a/app/controllers/surveys/building_ownerships_controller.rb
+++ b/app/controllers/surveys/building_ownerships_controller.rb
@@ -4,30 +4,32 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingTenure")
       @ownership_information = BuildingOwnership.new(survey: @survey)
     end
 
     def create
       ownership_information = survey.sections.build content: BuildingOwnership.new(building_ownership_params)
       if ownership_information.save
-        redirect_to next_survey_section(current_section: ownership_information, survey: survey)
+        next_section = section(survey, "BuildingHeight")
+        redirect_to next_survey_section(current_section: ownership_information, survey: survey, next_section: next_section)
       end
     end
 
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingTenure")
       @ownership_information = building_ownership
     end
 
     def update
       if building_ownership.update building_ownership_params
-        if session[:previous_url] == new_survey_building_height_url(survey)
-          redirect_to new_survey_building_height_url(survey)
-        else
+        if session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
+        else
+          next_section = section(survey, "BuildingHeight")
+          redirect_to next_survey_section(current_section: building_ownership.section, survey: survey, next_section: next_section)
         end
       end
     end
@@ -36,10 +38,6 @@ module Surveys
 
     def survey
       Survey.find params[:survey_id]
-    end
-
-    def section(survey)
-      survey.sections.find_by(content_type: "BuildingTenure")
     end
 
     def building_ownership

--- a/app/controllers/surveys/building_statuses_controller.rb
+++ b/app/controllers/surveys/building_statuses_controller.rb
@@ -10,8 +10,9 @@ module Surveys
     def create
       building_status = BuildingStatus.new(building_status_params)
       if building_status.save
+        next_section = section(survey, "BuildingTenure")
         survey.sections.create content: building_status
-        redirect_to next_survey_section(current_section: building_status.section, survey: survey)
+        redirect_to next_survey_section(current_section: building_status.section, survey: survey, next_section: next_section)
       else
         respond_to do |format|
           @building_status = building_status
@@ -30,10 +31,11 @@ module Surveys
 
     def update
       if building_status.update building_status_params
-        if session[:previous_url] == new_survey_building_tenure_url(survey) && !building_status.should_terminate_survey?
-          redirect_to new_survey_building_tenure_path(survey)
-        else
+        if session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
+        else
+          next_section = section(survey, "BuildingTenure")
+          redirect_to next_survey_section(current_section: building_status.section, survey: survey, next_section: next_section)
         end
       end
     end

--- a/app/controllers/surveys/building_tenures_controller.rb
+++ b/app/controllers/surveys/building_tenures_controller.rb
@@ -4,21 +4,22 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingStatus")
       @building_tenure = BuildingTenure.new(survey: survey)
     end
 
     def create
       building_tenure = BuildingTenure.new(building_tenure_params)
       if building_tenure.save
+        next_section = section(survey, "BuildingOwnership")
         survey.sections.create content: building_tenure
-        redirect_to next_survey_section(current_section: building_tenure.section, survey: survey)
+        redirect_to next_survey_section(current_section: building_tenure.section, survey: survey, next_section: next_section)
       else
         respond_to do |format|
           @building_tenure = building_tenure
           @survey = survey
-          @section = section(@survey)
-          format.html { render :new  }
+          @section = section(@survey, "BuildingStatus")
+          format.html { render :new }
         end
       end
     end
@@ -26,16 +27,17 @@ module Surveys
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingStatus")
       @building_tenure = building_tenure
     end
 
     def update
       if building_tenure.update building_tenure_params
-        if session[:previous_url] == new_survey_building_ownership_url(survey)
-          redirect_to new_survey_building_ownership_url(survey)
-        else
+        if session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
+        else
+          next_section = section(survey, "BuildingOwnership")
+          redirect_to next_survey_section(current_section: building_tenure.section, survey: survey, next_section: next_section)
         end
       end
     end
@@ -44,10 +46,6 @@ module Surveys
 
       def survey
         Survey.find params[:survey_id]
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingStatus")
       end
 
       def building_tenure

--- a/app/controllers/surveys/building_walls_controller.rb
+++ b/app/controllers/surveys/building_walls_controller.rb
@@ -4,12 +4,12 @@ module Surveys
 
     def index
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingHeight")
     end
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingHeight")
       @building_wall = BuildingWall.new(survey: @survey)
       @options_for_materials = materials
     end
@@ -32,7 +32,7 @@ module Surveys
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingHeight")
       @building_wall = building_wall
       @options_for_materials = materials
     end
@@ -51,7 +51,9 @@ module Surveys
         if session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
         else
-          redirect_to next_survey_section(current_section: building_wall.section, survey: survey)
+          section = section(survey, "BuildingWall")
+          next_section = section(survey, "Materials")
+          redirect_to next_survey_section(current_section: section, survey: survey, next_section: next_section)
         end
       end
     end
@@ -72,10 +74,6 @@ module Surveys
 
       def filtered_materials
         params[:building_wall][:materials].reject { |n| n.blank? }
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingHeight")
       end
 
       def materials

--- a/app/controllers/surveys/external_walls_material_details_controller.rb
+++ b/app/controllers/surveys/external_walls_material_details_controller.rb
@@ -4,7 +4,7 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingExternalWallStructure")
       @external_wall_structure = external_wall_structure
       @material_detail_list = MaterialDetailList.new(
         external_structure_name: required_detail,
@@ -15,21 +15,23 @@ module Surveys
     def create
       material_detail_list = MaterialDetailList.new detail_list_params
       if material_detail_list.save
-        redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey)
+        next_section = nil
+        redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey, next_section: next_section)
       end
     end
 
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingExternalWallStructure")
       @external_wall_structure = external_wall_structure
       @material_detail_list = material_detail_list
     end
 
     def update
       if material_detail_list.update detail_list_params
-        redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey)
+        next_section = nil
+        redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey, next_section: next_section)
       end
     end
 
@@ -49,10 +51,6 @@ module Surveys
 
       def material_detail_list
         MaterialDetailList.find params[:id]
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingExternalWallStructure")
       end
 
       def detail_list_params

--- a/app/controllers/surveys/materials_controller.rb
+++ b/app/controllers/surveys/materials_controller.rb
@@ -4,7 +4,7 @@ module Surveys
 
     def new
       @survey = survey
-      @section = section(@survey)
+      @section = section(@survey, "BuildingWall")
       @building_wall_materials = building_wall
     end
 
@@ -41,10 +41,6 @@ module Surveys
 
       def building_wall
         BuildingWall.find params[:building_wall_id]
-      end
-
-      def section(survey)
-        survey.sections.find_by(content_type: "BuildingWall")
       end
 
       def all_materials

--- a/app/models/survey_sequence_router.rb
+++ b/app/models/survey_sequence_router.rb
@@ -1,5 +1,6 @@
 class SurveySequenceRouter
   include Rails.application.routes.url_helpers
+  include SurveyRoutable
 
   attr_reader :survey
 
@@ -15,22 +16,48 @@ class SurveySequenceRouter
     survey.sections.find_by(content_type: "BuildingWall").content_id
   end
 
-  def next_section_for(current_section)
+  def next_section_for(current_section, next_section)
     return survey_summary_path(survey) if current_section.should_terminate_survey?
 
     case current_section.class.name
     when "BuildingStatus"
-      new_survey_building_tenure_path(survey)
+      if next_section != nil
+        edit_survey_building_tenure_path(survey.id, next_section.content_id)
+      else
+        new_survey_building_tenure_path(survey)
+      end
     when "BuildingTenure"
-      new_survey_building_ownership_path(survey)
+      if next_section != nil
+        edit_survey_building_ownership_path(survey.id, next_section.content_id)
+      else
+        new_survey_building_ownership_path(survey)
+      end
     when "BuildingOwnership"
-      new_survey_building_height_path(survey)
+      if next_section != nil
+        edit_survey_building_height_path(survey.id, next_section.content_id)
+      else
+        new_survey_building_height_path(survey)
+      end
     when "BuildingHeight"
-      survey_building_walls_path(survey)
+      if next_section != nil
+        edit_survey_building_wall_path(survey.id, next_section.content_id)
+      else
+        survey_building_walls_path(survey)
+      end
     when "BuildingWall"
-      new_survey_building_wall_material_path(survey, building_wall_id: building_wall)
+      material = Material.find_by(building_wall_id: next_section.content_id)
+      if material != nil
+        edit_survey_building_wall_material_path(survey.id, next_section.content_id, material.id)
+      else
+        new_survey_building_wall_material_path(survey, building_wall_id: building_wall)
+      end
     when "Materials"
-      new_survey_building_external_wall_structure_path(survey)
+      section = section(survey, "BuildingExternalWallStructure")
+      if section != nil
+        edit_survey_building_external_wall_structure_path(survey)
+      else
+        new_survey_building_external_wall_structure_path(survey)
+      end
     when "BuildingExternalWallStructure"
       if current_section.incomplete?
         new_survey_building_external_wall_structure_material_detail_list_path(

--- a/spec/models/survey_sequence_router_spec.rb
+++ b/spec/models/survey_sequence_router_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe SurveySequenceRouter, "#next_section_for" do
   it "returns the survey summary path if the current section should terminate the survey" do
     survey = build_stubbed :survey
     content = build_stubbed :building_status, status: "demolished"
+    next_section = nil
     section = build_stubbed :section, content: content, survey: survey
 
-    next_section_path = SurveySequenceRouter.for(survey).next_section_for section.content
+    next_section_path = SurveySequenceRouter.for(survey).next_section_for(section.content, next_section)
 
     expect(next_section_path).to eq survey_summary_path(survey)
   end
@@ -16,9 +17,10 @@ RSpec.describe SurveySequenceRouter, "#next_section_for" do
   it "returns the survey building tenure path if the current section is 'BuildingStatus'" do
     survey = build_stubbed :survey
     content = build_stubbed :building_status, status: "existing"
+    next_section = nil
     section = build_stubbed :section, content: content, survey: survey
 
-    next_section_path = SurveySequenceRouter.for(survey).next_section_for section.content
+    next_section_path = SurveySequenceRouter.for(survey).next_section_for(section.content, next_section)
 
     expect(next_section_path).to eq new_survey_building_tenure_path(survey)
   end
@@ -26,9 +28,10 @@ RSpec.describe SurveySequenceRouter, "#next_section_for" do
   it "returns the survey building ownership path if the current section is 'BuildingTenure'" do
     survey = build_stubbed :survey
     content = build_stubbed :building_tenure
+    next_section = nil
     section = build_stubbed :section, content: content, survey: survey
 
-    next_section_path = SurveySequenceRouter.for(survey).next_section_for section.content
+    next_section_path = SurveySequenceRouter.for(survey).next_section_for(section.content, next_section)
 
     expect(next_section_path).to eq new_survey_building_ownership_path(survey)
   end

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe "Building manager views survey reply summary" do
       choose "Owner freeholder", visible: false
       click_on "Continue"
       choose "Yes", visible: false
+      within "fieldset", text: "If known, what is the height of this building?" do
+        fill_in "In meters", with: 20
+        fill_in "In storeys", with: 10
+      end
+
       click_on "Continue"
 
       expect(page).to have_link "Back"
@@ -89,8 +94,8 @@ RSpec.describe "Building manager views survey reply summary" do
       choose "Yes", visible: false
 
       within "fieldset", text: "If known, what is the height of this building?" do
-        fill_in "In meters", with: 20
-        fill_in "In storeys", with: 10
+        fill_in "In meters", with: 22
+        fill_in "In storeys", with: 11
       end
 
       click_on "Continue"

--- a/spec/system/building_manager_views_survey_reply_summary_spec.rb
+++ b/spec/system/building_manager_views_survey_reply_summary_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Building manager views survey reply summary" do
     create :section, content: building_ownership, survey: survey
     building_tenure = create :building_tenure, tenure_type: "private_residential", survey: survey
     create :section, content: building_tenure, survey: survey
+    building_wall = create :building_wall, survey: survey
+    create :section, content: building_wall, survey: survey
     building_height = create :building_height, higher_than_18_meters: true, height_in_storeys: 4, height_in_meters: 20, survey: survey
     create :section, content: building_height, survey: survey
     building_wall = create :building_wall, survey: survey


### PR DESCRIPTION
This change was necessary because when user was clicking back_link and going back several pages, when clicking continue they were redirected to summary page instead of the next section

Right now user can go as many sections back as they want, after clicking "continue" they will be redirected to the next section (or edit page of the next session, or new page of the next session or the summary page)

Didn't apply that logic to building_walls and materials, because update method is not implemented yet, another developer is working on that 

Link to the story: https://trello.com/c/gYdSPg3f/107-as-a-building-owner-when-filling-in-the-survey-i-was-to-go-back-as-many-sections-as-i-want-to-be-able-to-update-my-answers-and-t