### PR TITLE
Add edit link back to external structures

### DIFF
--- a/app/views/surveys/building_external_wall_structures/_form.html.erb
+++ b/app/views/surveys/building_external_wall_structures/_form.html.erb
@@ -1,3 +1,4 @@
+<%= render 'application/back_link', chosen_path: edit_survey_building_wall_path(@survey.id, @section.content_id) unless @building_external_wall_structure.errors.any? %>
 <div data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
   <%= form_with model: [@survey, @building_external_wall_structure], local: true do |form_builder| %>
     <% if @building_external_wall_structure.errors.any? %>

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -128,6 +128,8 @@ RSpec.describe "Building manager views survey reply summary" do
 
     it "displays an error if no building external wall options are selected" do
       survey = create(:survey)
+      building_wall = create :building_wall, survey: survey
+      create :section, content: building_wall, survey: survey
       visit new_survey_building_external_wall_structure_path(survey)
 
       click_on "Continue"


### PR DESCRIPTION
* When merging, the edit link disappeared from the commit that was meant to fix it
* This also fixes the problem of there being no content id on save - the edit link isn't rendered if there are errors on the form
* Tests also had to be modified to add a previous section so content_id isn't null