### PR TITLE
Add edit ability to materials and insulations

### DIFF
--- a/app/controllers/surveys/building_walls_controller.rb
+++ b/app/controllers/surveys/building_walls_controller.rb
@@ -35,6 +35,7 @@ module Surveys
       @section = section(@survey, "BuildingHeight")
       @building_wall = building_wall
       @options_for_materials = materials
+      @other_material = building_wall.materials.where(name: "Other").map { | material | material.details }
     end
 
     def update
@@ -46,15 +47,12 @@ module Surveys
         end
       }
       building_wall.materials.each { |obj| obj.destroy unless building_materials.include?(obj.name) }
+      duplicate_other = building_wall.materials.where(name: "Other")
+      duplicate_other.count > 1 ? duplicate_other.first.destroy : ''
 
       if building_wall.save
-        if session[:previous_url] == survey_summary_url(survey)
-          redirect_to survey_summary_path(survey)
-        else
-          section = section(survey, "BuildingWall")
-          next_section = section(survey, "Materials")
-          redirect_to next_survey_section(current_section: section, survey: survey, next_section: next_section)
-        end
+        next_section = section(survey, "Materials")
+        redirect_to next_survey_section(current_section: building_wall.section, survey: survey, next_section: next_section)
       end
     end
 

--- a/app/controllers/surveys/materials_controller.rb
+++ b/app/controllers/surveys/materials_controller.rb
@@ -14,7 +14,9 @@ module Surveys
         redirect_to survey_building_wall_materials_details_path(survey_id: survey.id, building_wall_id: building_wall.id)
       elsif params[:building_wall][:insulation]
         params[:building_material].each { |key, val|  Material.find_by_id(key).update(insulation_material: val) }
-        if insulation_section_complete?
+        if insulation_section_complete? && !next_section_incomplete?
+          redirect_to survey_summary_path(survey)
+        elsif insulation_section_complete? && next_section_incomplete?
           redirect_to new_survey_building_external_wall_structure_path(survey)
         else
           redirect_to survey_building_wall_materials_details_path(survey_id: survey.id, building_wall_id: building_wall.id)
@@ -23,6 +25,8 @@ module Surveys
     end
 
     def material_partial
+      @survey = survey
+      @section = section(@survey, "BuildingWall")
       @building_wall = building_wall
       @options_for_insulation = insulations
       @material = all_materials.first
@@ -50,6 +54,11 @@ module Surveys
       def insulation_section_complete?
         all_materials.blank?
       end
+
+      def next_section_incomplete?
+        BuildingExternalWallStructure.find_by(survey_id: survey.id).blank?
+      end
+
 
       def insulations
         [

--- a/app/models/survey_sequence_router.rb
+++ b/app/models/survey_sequence_router.rb
@@ -45,7 +45,7 @@ class SurveySequenceRouter
         survey_building_walls_path(survey)
       end
     when "BuildingWall"
-      material = Material.find_by(building_wall_id: next_section.content_id)
+      material = Material.find_by(building_wall_id: next_section)
       if material != nil
         edit_survey_building_wall_material_path(survey.id, next_section.content_id, material.id)
       else

--- a/app/views/surveys/building_walls/_form.html.erb
+++ b/app/views/surveys/building_walls/_form.html.erb
@@ -20,7 +20,7 @@
           <% end %>
           <div class="govuk-form-group govuk-visually-hidden" id="other_material_details" %>
             <%= f.label :details, "Please describe the selected material", class: "govuk-label" %>
-            <%= f.text_field :details, class: "govuk-input govuk-input--width-20" %>
+            <%= f.text_field :details, class: "govuk-input govuk-input--width-20", value: @other_material ? @other_material : '' %>
           </div>
           <br>
           <%= f.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/surveys/materials/_form.html.erb
+++ b/app/views/surveys/materials/_form.html.erb
@@ -1,3 +1,4 @@
+<%= render 'application/back_link', chosen_path: edit_survey_building_wall_path(@survey.id, @section.content_id) %>
 <div data-controller="building-status">
   <%= form_with model: [@survey, @building_wall_materials], url: survey_building_wall_materials_path, local: true  do |f| %>
     <div class="govuk-form-group">

--- a/app/views/surveys/materials/insulation_material.html.erb
+++ b/app/views/surveys/materials/insulation_material.html.erb
@@ -1,3 +1,4 @@
+<%= render 'application/back_link', chosen_path: edit_survey_building_wall_path(@survey.id, @section.content_id) %>
 <%= form_with model: [@survey, @building_wall], url: survey_building_wall_materials_details_path do |f| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -102,6 +102,39 @@ RSpec.describe "Building manager views survey reply summary" do
 
       expect(page).to have_text("External features of the building")
     end
+
+    it "allows managers to modify the building's external materials" do
+      survey = create :survey
+      building_height = create :building_height, higher_than_18_meters: true, height_in_storeys: 4, height_in_meters: 20, survey: survey
+      create :section, content: building_height, survey: survey
+      building_wall = create :building_wall, survey: survey
+      create :section, content: building_wall, survey: survey
+      material_one = create :material, name: "Brick", percentage: "80", insulation_material: "None", building_wall: building_wall
+      material_two = create :material, name: "Other",  percentage: "20", details: "Sheep", insulation_material: "Glass", building_wall: building_wall
+      external_wall_structure = create :building_external_wall_structure, has_no_external_structures: true, survey: survey
+      visit edit_survey_building_wall_path(survey_id: survey, id: building_wall)
+      uncheck 'Brick'
+      check 'Brick slips'
+
+      uncheck 'Other'
+      check 'Other'
+      fill_in "Please describe the selected material", with: "Candy canes"
+      click_on "Continue"
+
+      fill_in "Brick slips", with: "40"
+      fill_in "Other", with: "60"
+      click_button "Continue"
+
+      expect(page).to have_content "What insulation is used in combination with Brick slips?"
+      choose "Brick slips.None", visible: false
+      click_button "Continue"
+
+      expect(page).to have_content "What insulation is used in combination with Other : Candy canes?"
+      choose "Other.Glass wool", visible: false
+      click_button "Continue"
+
+      expect(page).to have_content "Brick slips - 40%, insulation: None Other Candy canes 60%, insulation: Glass wool"
+    end
   end
 
   context "errors" do


### PR DESCRIPTION
- Ensures material percentages can be edited
- Because material names are being read as strings, the update method has to check and remove duplicates + unnecessary materials - particularly due to the "Other" string names
- Ensures routing goes to summary if the next section has been completed