### PR TITLE
Login to admin area

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,5 @@
+module Admin
+  class AdminController < ApplicationController
+    before_action :authenticate_user!, unless: :devise_controller?
+  end
+end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,6 @@
+module Admin
+  class DashboardsController < AdminController
+    def show
+    end
+  end
+end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class SessionsController < Devise::SessionsController
+    protected
+
+      def after_sign_in_path_for(resource)
+        stored_location_for(resource) || admin_dashboard_path
+      end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,3 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :recoverable, :rememberable, :validatable
-  has_secure_password
+  devise :database_authenticatable, :rememberable, :validatable
 end

--- a/app/views/admin/_flash.html.erb
+++ b/app/views/admin/_flash.html.erb
@@ -1,0 +1,16 @@
+<% if flash[:alert] %>
+  <div class="govuk-error-summary">
+    <h2 class="govuk-error-summary__title">
+      There was a problem signining in
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list">
+        <li>
+          <span class="govuk-error-message">
+            <%= alert %>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l">Admin dashboard</h1>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,0 +1,37 @@
+<% if flash[:alert] %>
+  <div class="govuk-error-summary">
+    <h2 class="govuk-error-summary__title">
+      There was a problem signining in
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list">
+        <li>
+          <span class="govuk-error-message">
+            <%= alert %>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">Sign in to access Admin area</h1>
+      </legend>
+      <div class="govuk-form-group">
+        <%= f.label :email, "Email address", class: "govuk-label" %>
+        <%= f.email_field :email, class: "govuk-input govuk-input--width-30", aspellcheck: false, autofocus: true, autocomplete: "email" %>
+      </div>
+      <div class="govuk-form-group">
+        <%= f.label :password, class: "govuk-label" %>
+        <%= f.password_field :password, class: "govuk-input govuk-input--width-30", autocomplete: "current-password" %>
+      </div>
+      <div class="actions">
+        <%= f.submit "Sign in", class: "govuk-button", data: { module: "govuk-button" } %>
+      </div>
+    </fieldset>
+  </div>
+<% end %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -17,6 +17,18 @@
       <a href="#" class="govuk-header__link govuk-header__link--service-name">
         Building Safety Platform
       </a>
+      <% if user_signed_in? %>
+        <nav>
+          <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+            <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+              <%= link_to "Dashboard", admin_dashboard_path, class: "govuk-header__link" %>
+            </li>
+            <li class="govuk-header__navigation-item">
+              <%= link_to "Sign out", admin_sign_out_path, method: :delete, class:"govuk-header__link" %>
+            </li>
+          </ul>
+        </nav>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,14 +9,8 @@
   </head>
   <body class="govuk-template__body">
     <%= render "application/header" %>
-    <% if notice %>
-      <p class="alert alert-success"><%= notice %></p>
-    <% end %>
-    <% if alert %>
-      <p class="alert alert-danger"><%= alert %></p>
-    <% end %>
     <div class="govuk-width-container app-width-container">
-      <main class="govuk-main-wrapper " id="main-content" role="main">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
         <%= yield %>
       </main>
       <%= javascript_pack_tag 'govuk', 'data-turbolinks-track': 'reload' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,17 @@
 Rails.application.routes.draw do
-  devise_for :users, only: %i(sessions confirmations passwords)
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  devise_for :users, only: :sessions, module: :admin
+
   root to: "surveys#index"
+
+  namespace :admin do
+    devise_scope :user do
+      get "sign_in", to: "sessions#new"
+      delete "sign_out", to: "sessions#destroy"
+    end
+    get "/", to: "dashboards#show"
+    resource :dashboard, only: [:show]
+  end
 
   get "new_survey", to: "surveys/start_surveys#new", as: :start_new_survey
   get "get_started", to: "surveys#new", as: :get_started

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :user do
+    sequence(:email) { |n| "southwark_admin_#{n}@example.com" }
+    password { "verySecure" }
   end
 end

--- a/spec/system/admin/signing_in_to_admin_dashboard_spec.rb
+++ b/spec/system/admin/signing_in_to_admin_dashboard_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Admin signs in" do
+  it "to view dashboard" do
+    user = create :user
+
+    visit "/admin"
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_on "Sign in"
+
+    expect(page).to have_content "Admin dashboard"
+
+    click_link "Sign out"
+
+    expect(current_path).to eq root_path
+    expect(page).not_to have_link "Dashboard", href: admin_dashboard_path
+  end
+end


### PR DESCRIPTION
In order to enter data and manage sending out surveys, an admin area was
required. This should also be password protected and have no links
accessible publicly.

This PR adds an admin dashboard, secured by email/password, and
accessible via "/admin" or "/admin/dashboard".

In order to display navigation to the admin user, the application header
was modified to include links, only displayable if a user is presently
signed in.