### PR TITLE
Redirect to summary page when not associated

### DIFF
--- a/app/models/building_ownership.rb
+++ b/app/models/building_ownership.rb
@@ -13,6 +13,6 @@ class BuildingOwnership < ApplicationRecord
   end
 
   def should_terminate_survey?
-    false
+    i_am_not_associated_with_this_building?
   end
 end

--- a/spec/models/building_ownership_spec.rb
+++ b/spec/models/building_ownership_spec.rb
@@ -26,8 +26,16 @@ RSpec.describe BuildingOwnership, "#reply" do
 end
 
 RSpec.describe BuildingOwnership, "#should_terminate_survey?" do
-  it "returns false" do
-    building_ownership = BuildingOwnership.new
+  it "returns true if the building ownership_status is 'i_am_not_associated_with_this_building'" do
+    building_ownership = building_ownership = BuildingOwnership.new ownership_status: "i_am_not_associated_with_this_building"
+
+    terminates_survey = building_ownership.should_terminate_survey?
+
+    expect(terminates_survey).to eq true
+  end
+
+  it "returns false if the building status is not 'i_am_not_associated_with_this_building'" do
+    building_ownership = building_ownership = BuildingOwnership.new ownership_status: "building_owner_freeholder"
 
     terminates_survey = building_ownership.should_terminate_survey?
 


### PR DESCRIPTION
if not associated with that building, app will redirect to summary page

# * Why was this change necessary?

if person filling in the survey is not associated with the building they are asked to fill the survey for, they shouldn't be allowed to fill the survey hence should be redirected to the summary page

# * How does it address the problem?
implement "should_terminate_survey?" method 

# * Are there any side effects?
# no

# Include a link to the ticket, if any.
https://trello.com/c/MT7xPWPs/128-as-a-non-building-owner-if-i-select-i-am-not-associated-with-this-building-on-the-your-relationship-to-the-building-page-i-shoul