### PR TITLE
Add validation to building_ownership section

### DIFF
--- a/app/controllers/surveys/building_ownerships_controller.rb
+++ b/app/controllers/surveys/building_ownerships_controller.rb
@@ -4,21 +4,26 @@ module Surveys
 
     def new
       @survey = survey
-      @ownership_information = BuildingOwnership.new(survey: @survey)
+      @building_ownership = BuildingOwnership.new(survey: @survey)
     end
 
     def create
-      ownership_information = survey.sections.build content: BuildingOwnership.new(building_ownership_params)
-      if ownership_information.save
+      building_ownership = BuildingOwnership.new(building_ownership_params)
+      if building_ownership.save
         next_section = section(survey, "BuildingStatus")
-        redirect_to next_survey_section(current_section: ownership_information, survey: survey, next_section: next_section)
+        survey.sections.create content: building_ownership
+        redirect_to next_survey_section(current_section: building_ownership.section, survey: survey, next_section: next_section)
+      else
+        @building_ownership = building_ownership
+        @survey = survey
+        render :new
       end
     end
 
     def edit
       session[:previous_url] = request.referer
       @survey = survey
-      @ownership_information = building_ownership
+      @building_ownership = building_ownership
     end
 
     def update

--- a/app/models/building_ownership.rb
+++ b/app/models/building_ownership.rb
@@ -1,6 +1,8 @@
 class BuildingOwnership < ApplicationRecord
   belongs_to :survey
   has_one :section, as: :content
+  validates :ownership_status, presence: { message: "can't be blank. Please select one value from the list" }
+  validate :association_to_building
 
   enum ownership_status: { building_owner_freeholder: 1, building_developer: 2, managing_agent: 3, other: 4, i_am_not_associated_with_this_building: 5 }
 
@@ -14,5 +16,11 @@ class BuildingOwnership < ApplicationRecord
 
   def should_terminate_survey?
     i_am_not_associated_with_this_building?
+  end
+
+  def association_to_building
+    if !i_am_not_associated_with_this_building? && (self.full_name.blank? || self.email.blank? || self.organisation.blank?)
+      errors.add(:empty_details, " Please provide your details")
+    end
   end
 end

--- a/app/views/surveys/building_ownerships/_form.html.erb
+++ b/app/views/surveys/building_ownerships/_form.html.erb
@@ -7,66 +7,91 @@
       </div>
     </div>
     <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <ul class="govuk-list govuk-list govuk-!-margin-bottom-8 govuk-!-margin-left-4">
-        <li><%= @survey.building.building_name %></li>
-        <li><%= @survey.building.street %></li>
-        <li><%= @survey.building.city_town %></li>
-        <li><%= @survey.building.postcode %></li>
-      </ul>
-      <div data-controller="building-status">
-        <%= form_with model: [@survey, @ownership_information] do |form_builder| %>
-          <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h2 class="govuk-heading-m">
-                  What is your role?
+      <div class="govuk-grid-column-two-thirds">
+        <ul class="govuk-list govuk-list govuk-!-margin-bottom-8 govuk-!-margin-left-4">
+          <li><%= @survey.building.building_name %></li>
+          <li><%= @survey.building.street %></li>
+          <li><%= @survey.building.city_town %></li>
+          <li><%= @survey.building.postcode %></li>
+        </ul>
+        <div data-controller="building-status">
+          <%= form_with model: [@survey, @building_ownership], local: true do |form_builder| %>
+            <% if @building_ownership.errors.any? %>
+              <div class="govuk-error-summary">
+                <h2 class="govuk-error-summary__title">
+                  There was a problem with your survey
                 </h2>
-              </legend>
-              <div class="govuk-radios govuk-!-margin-bottom-4">
-                <%= form_builder.collection_radio_buttons :ownership_status, @ownership_information.class.ownership_statuses, :first, :first do |radio_button| %>
-                  <div class="govuk-radios__item">
-                    <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-status#toggle" }) %>
-                    <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
-                  </div>
-                <% end %>
+                <div class="govuk-error-summary__body">
+                  <ul class="govuk-list">
+                    <% @building_ownership.errors.full_messages.each do |msg| %>
+                      <li>
+                        <span class="govuk-error-message">
+                          <%= msg %>
+                        </span>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
               </div>
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h2 class="govuk-heading-m">
-                  Is this a right-to-manage company?
-                </h2>
-              </legend>
-              <div class="govuk-radios govuk-!-margin-bottom-4">
-                <%= form_builder.collection_radio_buttons :right_to_manage_company, [[true, 'Yes'] ,[false, 'No']], :first, :last do |radio_button| %>
-                  <div class="govuk-radios__item">
-                    <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-ownership#toggle" }) %>
-                    <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
-                  </div>
-                <% end %>
-              </div>
-              <br>
-              <h2 class="govuk-heading-m"><%= form_builder.label :full_name, "Name" %></h2>
-              <%= form_builder.text_field :full_name, class: "govuk-input govuk-input--width-10 govuk-!-margin-bottom-3" %>
-              <h2 class="govuk-heading-m"><%= form_builder.label :email, "Email" %></h2>
-              <%= form_builder.text_field :email, class: "govuk-input govuk-input--width-10 govuk-!-margin-bottom-3" %>
-              <h2 class="govuk-heading-m"><%= form_builder.label :organisation, "Organisation" %></h2>
-              <%= form_builder.text_field :organisation, class: "govuk-input govuk-input--width-10" %>
-            </fieldset>
-          </div>
-          <div class="govuk-form-group hidden" data-target="building-status.details">
-            <h2 class="govuk-label-wrapper">
-              <label class="govuk-label govuk-label--m" for="more-detail">
-                If relevant to the building please provide any other information about how it is managed?
-              </label>
-            </h2>
-            <div id="more-detail-hint" class="govuk-hint">
-              Do not include personal or financial information, like your National Insurance number or credit card details.
+            <% end %>
+            <div class="govuk-form-group <%= " govuk-form-group--error" if @building_ownership.errors.messages[:ownership_status].any? %>">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <h2 class="govuk-heading-m">
+                    What is your role?
+                  </h2>
+                </legend>
+                <div class="govuk-radios govuk-!-margin-bottom-4">
+                  <%= form_builder.collection_radio_buttons :ownership_status, @building_ownership.class.ownership_statuses, :first, :first do |radio_button| %>
+                    <div class="govuk-radios__item">
+                      <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-status#toggle" }) %>
+                      <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
+                    </div>
+                  <% end %>
+                </div>
+              </fieldset>
             </div>
-            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
-          </div>
-          <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
-        <% end %>
-      </div>
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <h2 class="govuk-heading-m">
+                    Is this a right-to-manage company?
+                  </h2>
+                </legend>
+                <div class="govuk-radios govuk-!-margin-bottom-4">
+                  <%= form_builder.collection_radio_buttons :right_to_manage_company, [[true, 'Yes'] ,[false, 'No']], :first, :last do |radio_button| %>
+                    <div class="govuk-radios__item">
+                      <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-ownership#toggle" }) %>
+                      <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
+                    </div>
+                  <% end %>
+                </div>
+             </fieldset>
+            </div>
+              <div class="govuk-form-group <%= " govuk-form-group--error" if @building_ownership.errors.messages[:empty_details].any? %>">
+              <fieldset class="govuk-fieldset">
+                <h2 class="govuk-heading-m"><%= form_builder.label :full_name, "Name" %></h2>
+                <%= form_builder.text_field :full_name, class: "govuk-input govuk-input--width-10 govuk-!-margin-bottom-3" %>
+                <h2 class="govuk-heading-m"><%= form_builder.label :email, "Email" %></h2>
+                <%= form_builder.text_field :email, class: "govuk-input govuk-input--width-10 govuk-!-margin-bottom-3" %>
+                <h2 class="govuk-heading-m"><%= form_builder.label :organisation, "Organisation" %></h2>
+                <%= form_builder.text_field :organisation, class: "govuk-input govuk-input--width-10" %>
+              </fieldset>
+            </div>
+            <div class="govuk-form-group hidden" data-target="building-status.details">
+              <h2 class="govuk-label-wrapper">
+                <label class="govuk-label govuk-label--m" for="more-detail">
+                  If relevant to the building please provide any other information about how it is managed?
+                </label>
+              </h2>
+              <div id="more-detail-hint" class="govuk-hint">
+                Do not include personal or financial information, like your National Insurance number or credit card details.
+              </div>
+              <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
+            </div>
+            <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
+          <% end %>
+        </div>
       </div>
     </div>
   </main>

--- a/spec/features/building_manager_journey_spec.rb
+++ b/spec/features/building_manager_journey_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe "Building manager functionality" do
       expect(page).to have_text("Your relationship to the building")
 
       choose "Building owner freeholder", visible: false
-      # add more tests
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
+
       click_button "Continue"
       expect(page).to have_text("Please confirm the status of this building")
 

--- a/spec/models/building_ownership_spec.rb
+++ b/spec/models/building_ownership_spec.rb
@@ -42,3 +42,19 @@ RSpec.describe BuildingOwnership, "#should_terminate_survey?" do
     expect(terminates_survey).to eq false
   end
 end
+
+RSpec.describe BuildingOwnership, "validation" do
+  it "throws an error if ownership_status is not present" do
+    building_ownership = BuildingOwnership.new
+
+    expect(building_ownership).not_to be_valid
+    expect(building_ownership.errors.added?(:ownership_status, "can't be blank. Please select one value from the list")).to be_truthy
+  end
+
+  it "throws an error if ownership_status is presented but name/email/organisation is blank" do
+    building_ownership = BuildingOwnership.new ownership_status: "building_owner_freeholder"
+
+    expect(building_ownership).not_to be_valid
+    expect(building_ownership.errors.added?(:empty_details, " Please provide your details")).to be_truthy
+  end
+end

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -13,9 +13,12 @@ RSpec.describe "Building manager views survey reply summary" do
       click_button "Continue"
     end
 
-
     it "allows managers to modify building ownership" do
       choose "Building owner freeholder", visible: false
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
+
       click_on "Continue"
 
       expect(page).to have_link "Back"
@@ -26,11 +29,11 @@ RSpec.describe "Building manager views survey reply summary" do
 
       choose "Building developer", visible: false
       choose "Yes", visible: false
-      within "fieldset" do
-        fill_in "Name", with: "Ana"
-        fill_in "Email", with: "test@test.com"
-        fill_in "Organisation", with: "Ana"
-      end
+
+      fill_in "Name", with: "Ana"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Ana"
+
       click_on "Continue"
 
       expect(page).to have_text("Please confirm the status of this building")
@@ -39,6 +42,9 @@ RSpec.describe "Building manager views survey reply summary" do
 
     it "allows managers to modify building status" do
        choose "Building owner freeholder", visible: false
+       fill_in "Name", with: "Pepito"
+       fill_in "Email", with: "test@test.com"
+       fill_in "Organisation", with: "Pepito&Co"
        click_on "Continue"
        choose "Existing", visible: false
        click_on "Continue"
@@ -57,6 +63,9 @@ RSpec.describe "Building manager views survey reply summary" do
 
     it "allows managers to modify building tenure" do
       choose "Building owner freeholder", visible: false
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
       click_on "Continue"
       choose "Existing", visible: false
       click_on "Continue"
@@ -78,6 +87,9 @@ RSpec.describe "Building manager views survey reply summary" do
 
     it "allows managers to modify building height" do
       choose "Building owner freeholder", visible: false
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
       click_on "Continue"
       choose "Existing", visible: false
       click_on "Continue"
@@ -161,10 +173,32 @@ RSpec.describe "Building manager views survey reply summary" do
       expect(page).to have_text "Please check the code provided on the letter or email."
     end
 
+    it "displays an error if building_ownership not selected" do
+      fill_in with: building.uprn
+      click_button "Continue"
+      click_on "Continue"
+
+      expect(page).to have_text "There was a problem with your survey"
+      expect(page).to have_text "Ownership status can't be blank. Please select one value from the list"
+    end
+
+    it "displays an error if building_ownership is selected but name/email and organisation is blank" do
+      fill_in with: building.uprn
+      click_button "Continue"
+      choose "Building owner freeholder", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text "There was a problem with your survey"
+      expect(page).to have_text "Empty details Please provide your details"
+    end
+
     it "displays an error if building_status not selected" do
       fill_in with: building.uprn
       click_button "Continue"
       choose "Building owner freeholder", visible: false
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
       click_on "Continue"
       click_on "Continue"
 
@@ -176,6 +210,9 @@ RSpec.describe "Building manager views survey reply summary" do
       fill_in with: building.uprn
       click_button "Continue"
       choose "Building owner freeholder", visible: false
+      fill_in "Name", with: "Pepito"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Pepito&Co"
       click_on "Continue"
       choose "Existing", visible: false
       click_on "Continue"

--- a/spec/system/building_manager_views_survey_reply_summary_spec.rb
+++ b/spec/system/building_manager_views_survey_reply_summary_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Building manager views survey reply summary" do
     survey = create :survey
     building_status = create :building_status, status: "existing", survey: survey
     create :section, content: building_status, survey: survey
-    building_ownership = create :building_ownership, ownership_status: "building_developer", survey: survey
+    building_ownership = create :building_ownership, ownership_status: "building_developer", full_name: "Pepe", email: "test@test.com", organisation: "Pepe&Co", survey: survey
     create :section, content: building_ownership, survey: survey
     building_tenure = create :building_tenure, tenure_type: "private_residential", survey: survey
     create :section, content: building_tenure, survey: survey


### PR DESCRIPTION
# * Why was this change necessary?

As a building owner I should specify my role
If role is not chosen, can not continue filling in the survey
If role is chosen but name/email/organisation is empty, throw an error

# * How does it address the problem?
adds validation to building ownership and checks that 1 option is selected from the list
if 1 option is selected (except "I am not associated to this building) but name/email/organisation is not selected throws an error

# * Are there any side effects?
# no

# Include a link to the ticket, if any.
https://trello.com/c/seALKfRT/97-validationas-a-building-owner-i-am-required-to-select-one-option-for-building-ownership