### PR TITLE
Redirect to relevant section after update

### DIFF
--- a/app/controllers/surveys/building_heights_controller.rb
+++ b/app/controllers/surveys/building_heights_controller.rb
@@ -31,8 +31,13 @@ module Surveys
     end
 
     def update
+      before_update = building_height.higher_than_18_meters?
       if building_height.update(building_height_params)
-        if session[:previous_url] == survey_summary_url(survey)
+        if !before_update && building_height.higher_than_18_meters?
+          next_section = section(survey, "BuildingWall")
+          redirect_to next_survey_section(current_section: building_height.section, survey: survey, next_section: next_section)
+        elsif
+          session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingWall")

--- a/app/controllers/surveys/building_ownerships_controller.rb
+++ b/app/controllers/surveys/building_ownerships_controller.rb
@@ -27,8 +27,13 @@ module Surveys
     end
 
     def update
+      before_update = building_ownership.ownership_status
       if building_ownership.update building_ownership_params
-        if session[:previous_url] == survey_summary_url(survey)
+        if before_update == "i_am_not_associated_with_this_building" && building_ownership.ownership_status != "i_am_not_associated_with_this_building"
+          next_section = section(survey, "BuildingStatus")
+          redirect_to next_survey_section(current_section: building_ownership.section, survey: survey, next_section: next_section)
+        elsif
+          session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingStatus")

--- a/app/controllers/surveys/building_statuses_controller.rb
+++ b/app/controllers/surveys/building_statuses_controller.rb
@@ -33,8 +33,13 @@ module Surveys
     end
 
     def update
+      before_update = building_status.status
       if building_status.update building_status_params
-        if session[:previous_url] == survey_summary_url(survey)
+        if before_update != "existing" && building_status.status == "existing"
+          next_section = section(survey, "BuildingTenure")
+          redirect_to next_survey_section(current_section: building_status.section, survey: survey, next_section: next_section)
+        elsif
+          session[:previous_url] == survey_summary_url(survey)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingTenure")

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -1,4 +1,6 @@
 require "rails_helper"
+### testing that back_links take you back to previous section and allow to modify answers
+### testing error messages if required fields are not selected
 
 RSpec.describe "Building manager views survey reply summary" do
   context "modifing previous answers" do

--- a/spec/system/surveys/relevant_section_spec.rb
+++ b/spec/system/surveys/relevant_section_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+# ##testing that user is redirected to the next relevant section after updating the answer coming from summary page
+
+RSpec.describe "Building manager views survey reply summary" do
+  context "modifing ownership, status and height" do
+    let!(:building) do
+      create :building
+    end
+
+    before do
+      visit root_path
+      click_on "Start now"
+      fill_in with: building.uprn
+      click_button "Continue"
+    end
+
+    it "redirects to the building_status section" do
+      choose "I am not associated with this building", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text("Check your answers")
+      expect(building_ownership_row).to have_text("I am not associated with this building")
+
+      within(building_ownership_row) { click_on "Change" }
+      choose "Building owner freeholder", visible: false
+      choose "Yes", visible: false
+      fill_in "Name", with: "Ana"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Ana"
+
+      click_on "Continue"
+
+      expect(page).to have_text("Please confirm the status of this building")
+    end
+
+    it "redirects to the building_tenure section" do
+      choose "Building owner freeholder", visible: false
+      choose "Yes", visible: false
+      fill_in "Name", with: "Ana"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Ana"
+      click_on "Continue"
+      choose "Demolished", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text("Check your answers")
+      expect(building_status_row).to have_text("Demolished")
+
+      within(building_status_row) { click_on "Change" }
+      choose "Existing", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text("Please indicate the building use")
+    end
+
+    it "redirects to the building_walls section" do
+      choose "Building owner freeholder", visible: false
+      choose "Yes", visible: false
+      fill_in "Name", with: "Ana"
+      fill_in "Email", with: "test@test.com"
+      fill_in "Organisation", with: "Ana"
+      click_on "Continue"
+      choose "Existing", visible: false
+      click_on "Continue"
+      choose "Social residential", visible: false
+      click_on "Continue"
+      choose "No", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text("Check your answers")
+      expect(building_height_row).to have_text("Under 18 meters tall - storey(s), meters")
+
+      within(building_height_row) { click_on "Change" }
+      choose "Yes", visible: false
+      click_on "Continue"
+
+      expect(page).to have_text("External features of the building")
+    end
+
+    def building_ownership_row
+      find('div[data-information-displayed="building-ownership"]')
+    end
+
+    def building_status_row
+      find('div[data-information-displayed="building-status"]')
+    end
+
+    def building_height_row
+      find('div[data-information-displayed="building-height"]')
+    end
+  end
+end


### PR DESCRIPTION
# * Why was this change necessary?

when changing statuses of building_ownership, building-status and building_height it was redirecting to summary page
Needed to implement logic, that would redirect to a relevant section.
ex. if building status was "demolish" and then updated to "existing", building owner should be redirected  to building_tenure section

# * How does it address the problem?
add logic to update method and redirects to the relevant section

# * Are there any side effects?
# no

# Include a link to the ticket, if any.
https://trello.com/c/yQAagZJP/52-as-a-building-owner-if-i-change-my-answer-i-then-need-to-answer-the-other-relevant-questions