### PR TITLE
Collapse building manager into building

### DIFF
--- a/app/controllers/building_managers_controller.rb
+++ b/app/controllers/building_managers_controller.rb
@@ -1,2 +1,0 @@
-class BuildingManagersController < ApplicationController
-end

--- a/app/controllers/surveys/start_surveys_controller.rb
+++ b/app/controllers/surveys/start_surveys_controller.rb
@@ -13,7 +13,7 @@ module Surveys
     private
 
       def building
-        Building.includes(:manager).find params[:for]
+        Building.find params[:for]
       end
   end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,4 +1,3 @@
 class Building < ApplicationRecord
-  belongs_to :manager, class_name: "BuildingManager"
   has_one :survey
 end

--- a/app/models/building_manager.rb
+++ b/app/models/building_manager.rb
@@ -1,3 +1,0 @@
-class BuildingManager < ApplicationRecord
-  has_many :buildings, foreign_key: :manager_id
-end

--- a/db/migrate/20200916100550_drop_building_managers.rb
+++ b/db/migrate/20200916100550_drop_building_managers.rb
@@ -1,0 +1,15 @@
+class DropBuildingManagers < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :buildings, :manager_id
+    remove_foreign_key :buildings, :building_managers
+    drop_table :building_managers
+  end
+
+  def down
+    create_table :building_managers do |t|
+      t.citext :email, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200916101452_add_proprietor_email_to_buildings.rb
+++ b/db/migrate/20200916101452_add_proprietor_email_to_buildings.rb
@@ -1,0 +1,6 @@
+class AddProprietorEmailToBuildings < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :buildings, :manager_id, :bigint
+    add_column :buildings, :proprietor_email, :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_155124) do
+ActiveRecord::Schema.define(version: 2020_09_16_101452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -37,13 +37,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_155124) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["survey_id"], name: "index_building_heights_on_survey_id"
-  end
-
-  create_table "building_managers", force: :cascade do |t|
-    t.citext "email", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_building_managers_on_email"
   end
 
   create_table "building_ownerships", force: :cascade do |t|
@@ -89,11 +82,10 @@ ActiveRecord::Schema.define(version: 2020_09_10_155124) do
     t.string "uprn"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "manager_id"
     t.string "street"
     t.string "city_town"
     t.string "postcode"
-    t.index ["manager_id"], name: "index_buildings_on_manager_id"
+    t.citext "proprietor_email"
   end
 
   create_table "material_detail_lists", force: :cascade do |t|
@@ -173,7 +165,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_155124) do
   add_foreign_key "building_statuses", "surveys"
   add_foreign_key "building_tenures", "surveys"
   add_foreign_key "building_walls", "surveys"
-  add_foreign_key "buildings", "building_managers", column: "manager_id"
   add_foreign_key "material_detail_lists", "building_external_wall_structures"
   add_foreign_key "materials", "building_walls"
   add_foreign_key "sections", "surveys"

--- a/spec/factories/building_managers.rb
+++ b/spec/factories/building_managers.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :building_manager do
-    sequence(:email) { |i| "beans#{i}@example.com" }
-  end
-end

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :building do
-    association :manager, factory: :building_manager
-
     building_name { "A place full of wonders" }
     street { "1 Union Street" }
     city_town { "London" }

--- a/spec/features/building_manager_journey_spec.rb
+++ b/spec/features/building_manager_journey_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Building manager functionality" do
-  let!(:building_manager) do
-    create :building_manager
-  end
   let!(:building) do
-    create :building, manager: building_manager
+    create :building
   end
 
   before do

--- a/spec/models/building_manager_spec.rb
+++ b/spec/models/building_manager_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe BuildingManager, "associations" do
-  it { is_expected.to have_many :buildings }
-end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
 RSpec.describe Building, "associations" do
-  it { is_expected.to belong_to(:manager).class_name("BuildingManager") }
   it { is_expected.to have_one :survey }
 end

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -2,11 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Building manager views survey reply summary" do
   context "modifing previous answers" do
-    let!(:building_manager) do
-      create :building_manager
-    end
     let!(:building) do
-      create :building, manager: building_manager
+      create :building
     end
 
     before do
@@ -146,11 +143,8 @@ RSpec.describe "Building manager views survey reply summary" do
   end
 
   context "errors" do
-    let!(:building_manager) do
-      create :building_manager
-    end
     let!(:building) do
-      create :building, manager: building_manager
+      create :building
     end
 
     before do


### PR DESCRIPTION
The building manager record, or entity, has become redundant in the
project. It was originally created with the intention of allowing
communication of several surveys/buildings to a single entity.

As the project developed, it has now become apparent that we will not be
addressing a single entity that owns many buildings and presenting a
list of surveys to complete.

On the other hand, now that we have finalized data to work with, having
a separate building manager entity makes the data import a two stage
process: we'd need to import all buildings and then re-run the import
in order to import building managers.

As such, it is a great example of the example "Make the change easy, then
make an easy change": by collapsing the building manager data into the
building table, we make it easier to manage data via importing, or even
via a CRUD interface, as we are only handling one model.

A small side effect is an accumulation of data in the building model,
but even then it doesn't strike me at this point as worth the trade-off.
It seems better to be able to ask a building "What is email address for
your proprietor?" than making any data import much more complex.