### PR TITLE
Display reference number as building UPRN

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -7,7 +7,7 @@ class SurveysController < ApplicationController
   end
 
   def show
-    @reference = survey.reference_id
+    @uprn = survey.building.uprn
   end
 
   def new

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,11 +1,4 @@
 class Survey < ApplicationRecord
   belongs_to :building
   has_many :sections
-  before_create :set_reference
-
-  private
-
-    def set_reference
-      self.reference_id = SecureRandom.hex(12).upcase
-    end
 end

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -8,7 +8,7 @@
         </h1>
         <div class="govuk-panel__body">
           Your reference number<br>
-          <strong><%= @reference %></strong>
+          <strong><%= @uprn %></strong>
         </div>
       </div>
       <p class="govuk-body">We have sent you a confirmation email.</p>

--- a/db/migrate/20200916105116_remove_reference_from_surveys.rb
+++ b/db/migrate/20200916105116_remove_reference_from_surveys.rb
@@ -1,0 +1,5 @@
+class RemoveReferenceFromSurveys < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :surveys, :reference_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,7 +162,6 @@ ActiveRecord::Schema.define(version: 2020_09_16_165118) do
     t.bigint "building_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "reference_id"
     t.index ["building_id"], name: "index_surveys_on_building_id"
   end
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9452321/93329672-70e0be00-f815-11ea-84e8-b64d53dcf8f9.png)

Story:
https://trello.com/c/yTEXgByO/133-on-completing-a-survey-i-want-to-see-a-uprn-instead-of-a-survey-reference-number-for-the-building

Removes reference and displays uprn instead