### PR TITLE
Add comments to building status

### DIFF
--- a/app/controllers/surveys/building_statuses_controller.rb
+++ b/app/controllers/surveys/building_statuses_controller.rb
@@ -30,6 +30,7 @@ module Surveys
       @survey = survey
       @building_status = building_status
       @previous_section = section(@survey, "BuildingOwnership")
+      @building_details = building_status.status_details
     end
 
     def update
@@ -50,7 +51,7 @@ module Surveys
       end
 
       def building_status_params
-        params.require(:building_status).permit(:status).merge(survey: survey)
+        params.require(:building_status).permit(:status, :status_details).merge(survey: survey)
       end
 
       def building_status

--- a/app/models/building_status.rb
+++ b/app/models/building_status.rb
@@ -3,7 +3,7 @@ class BuildingStatus < ApplicationRecord
   has_one :section, as: :content
   validates :status, presence: { message: "can't be blank. Please select one value from the list" }
 
-  enum status: { existing: 1, demolished: 2, duplicate: 3, not_recognized: 4 }
+  enum status: { existing: 1, demolished: 2 }
 
   def name
     "Building status"

--- a/app/views/surveys/building_statuses/_form.html.erb
+++ b/app/views/surveys/building_statuses/_form.html.erb
@@ -1,51 +1,56 @@
 <%= render 'application/back_link', chosen_path: edit_survey_building_ownership_path(@survey.id, @previous_section.content_id) %>
-<div data-controller="building-status">
-  <%= form_with model: [@survey, @building_status], local: true do |form_builder| %>
-    <% if @building_status.errors.any? %>
-      <div class="govuk-error-summary">
-        <h2 class="govuk-error-summary__title">
-          There was a problem with your survey
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list">
-            <% @building_status.errors.full_messages.each do |msg| %>
-              <li>
-                <span class="govuk-error-message">
-                  <%= msg %>
-                </span>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
-    <div class="govuk-form-group <%= " govuk-form-group--error" if @building_status.errors.any? %>">
-      <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint changed-name-error">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">
-            Please confirm the status of this building
-          </h1>
-        </legend>
-        <div class="govuk-radios">
-          <%= form_builder.collection_radio_buttons :status, @building_status.class.statuses, :first, :first do |radio_button| %>
-            <div class="govuk-radios__item">
-              <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-status#toggle" }) %>
-              <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div data-controller="building-status">
+      <%= form_with model: [@survey, @building_status], local: true do |form_builder| %>
+        <% if @building_status.errors.any? %>
+          <div class="govuk-error-summary">
+            <h2 class="govuk-error-summary__title">
+              There was a problem with your survey
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list">
+                <% @building_status.errors.full_messages.each do |msg| %>
+                  <li>
+                    <span class="govuk-error-message">
+                      <%= msg %>
+                    </span>
+                  </li>
+                <% end %>
+              </ul>
             </div>
-          <% end %>
+          </div>
+        <% end %>
+        <div class="govuk-form-group <%= " govuk-form-group--error" if @building_status.errors.any? %>">
+          <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint changed-name-error">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Please confirm the status of this building
+              </h1>
+            </legend>
+            <div class="govuk-radios">
+              <%= form_builder.collection_radio_buttons :status, @building_status.class.statuses, :first, :first do |radio_button| %>
+                <div class="govuk-radios__item">
+                  <%= radio_button.radio_button(class: "govuk-radios__input", data: { action: "change->building-status#toggle" }) %>
+                  <%= radio_button.label(class: "govuk-label govuk-radios__label") { radio_button.text.humanize } %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
         </div>
-      </fieldset>
-    </div>
-    <div class="govuk-form-group hidden" data-target="building-status.details">
-      <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="more-detail">
-          Can you provide more detail?
-        </label>
-      </h1>
-      <div id="more-detail-hint" class="govuk-hint">
-        Do not include personal or financial information, like your National Insurance number or credit card details.
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-label-wrapper">
+                <label class="govuk-label govuk-label--l" for="more-detail">
+                  Can you provide more detail?
+                </label>
+              </h1>
+              <%= form_builder.text_area :status_details, class: "govuk-textarea", id: "status_details", rows: "5",value: @building_details ? @building_details : '' %>
+            </fieldset>
+          </div>
+          <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
+        <% end %>
       </div>
-      <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
     </div>
-    <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
-  <% end %>
-</div>
+  </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,5 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-building_manager = BuildingManager.find_or_create_by(email: "example@example.com")
-building = Building.find_or_create_by(building_name: "Oslo Tower", street: "1 Union Street", city_town: "London", postcode: "NW1235", uprn: "20012524507", manager: building_manager)
+building = Building.find_or_create_by(building_name: "Oslo Tower", street: "1 Union Street", city_town: "London", postcode: "NW1235", uprn: "20012524507")
 survey = Survey.find_or_create_by(building_id: building.id)

--- a/spec/models/building_status_spec.rb
+++ b/spec/models/building_status_spec.rb
@@ -17,11 +17,11 @@ end
 
 RSpec.describe BuildingStatus, "#reply" do
   it "returns a humanized form of the status" do
-    building_status = BuildingStatus.new status: "not_recognized"
+    building_status = BuildingStatus.new status: "existing"
 
     reply = building_status.reply
 
-    expect(reply).to eq "Not recognized"
+    expect(reply).to eq "Existing"
   end
 end
 

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe "Building manager views survey reply summary" do
        fill_in "Organisation", with: "Pepito&Co"
        click_on "Continue"
        choose "Existing", visible: false
+       within "fieldset", text: "Can you provide more detail?" do
+         fill_in "status_details", with: "I really want some apple pie"
+       end
+
        click_on "Continue"
 
        expect(page).to have_link "Back"
@@ -54,6 +58,7 @@ RSpec.describe "Building manager views survey reply summary" do
        click_on "Back"
 
        expect(page).to have_text("Please confirm the status of this building")
+       expect(page).to have_text("I really want some apple pie")
 
        choose "Demolished", visible: false
        click_on "Continue"


### PR DESCRIPTION
- Removes unnecessary statuses as per this story https://trello.com/c/jSZBHPfG/142-html-update-building-status-page
- Realised comments on status were not being saved, have fixed that