### PR TITLE
Allow materials to be deleted

### DIFF
--- a/app/controllers/surveys/materials_controller.rb
+++ b/app/controllers/surveys/materials_controller.rb
@@ -28,6 +28,7 @@ module Surveys
       @previous_section = section(@survey, "BuildingHeight")
       @options_for_materials = materials
       @building_wall = building_wall
+      @other_material = building_wall.materials.where(name: "Other").pluck(:details)
     end
 
     def update

--- a/db/migrate/20200916165022_remove_foreign_keys.rb
+++ b/db/migrate/20200916165022_remove_foreign_keys.rb
@@ -1,0 +1,6 @@
+class RemoveForeignKeys < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :insulations, :materials
+    remove_foreign_key :percentages, :materials
+  end
+end

--- a/db/migrate/20200916165118_add_foreign_key_constraints.rb
+++ b/db/migrate/20200916165118_add_foreign_key_constraints.rb
@@ -1,0 +1,6 @@
+class AddForeignKeyConstraints < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :insulations, :materials, null: false, foreign_key: true, on_delete: :cascade
+    add_foreign_key :percentages, :materials, null: false, foreign_key: true, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_132752) do
+ActiveRecord::Schema.define(version: 2020_09_16_165118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -185,10 +185,10 @@ ActiveRecord::Schema.define(version: 2020_09_16_132752) do
   add_foreign_key "building_statuses", "surveys"
   add_foreign_key "building_tenures", "surveys"
   add_foreign_key "building_walls", "surveys"
-  add_foreign_key "insulations", "materials"
+  add_foreign_key "insulations", "materials", on_delete: :cascade
   add_foreign_key "material_detail_lists", "building_external_wall_structures"
   add_foreign_key "materials", "building_walls"
-  add_foreign_key "percentages", "materials"
+  add_foreign_key "percentages", "materials", on_delete: :cascade
   add_foreign_key "sections", "surveys"
   add_foreign_key "surveys", "buildings"
 end


### PR DESCRIPTION
- Currently the association between materials and percentages doesn't allow for record deletion on update
- This also ensures if "other" has been selected then the field will be pre-filled