### PR TITLE
Delete not relevant info if status updated

### DIFF
--- a/app/controllers/concerns/survey_routable.rb
+++ b/app/controllers/concerns/survey_routable.rb
@@ -8,4 +8,23 @@ module SurveyRoutable
   def section(survey, section)
     survey.sections.find_by(content_type: section)
   end
+
+  def delete_not_relevant_info(current_section:, next_section:)
+    return if next_section == nil
+    return if next_section != nil && !current_section.should_terminate_survey?
+
+    case current_section.name
+    when "Building ownership"
+      content_type_to_destroy = ["BuildingStatus", "BuildingTenure", "BuildingHeight", "BuildingWall", "Materials", "BuildingExternalWallStructure"]
+      survey.sections.where(content_type: content_type_to_destroy).each { |section| section.try(:destroy) }
+    when "Building status"
+      content_type_to_destroy = ["BuildingTenure", "BuildingHeight", "BuildingWall", "Materials", "BuildingExternalWallStructure"]
+      survey.sections.where(content_type: content_type_to_destroy).each { |section| section.try(:destroy) }
+    when "Building height"
+      content_type_to_destroy = ["BuildingWall", "Materials", "BuildingExternalWallStructure"]
+      survey.sections.where(content_type: content_type_to_destroy).each { |section| section.try(:destroy) }
+    else
+      nil
+    end
+  end
 end

--- a/app/controllers/surveys/building_heights_controller.rb
+++ b/app/controllers/surveys/building_heights_controller.rb
@@ -36,8 +36,9 @@ module Surveys
         if !before_update && building_height.higher_than_18_meters?
           next_section = section(survey, "BuildingWall")
           redirect_to next_survey_section(current_section: building_height.section, survey: survey, next_section: next_section)
-        elsif
-          session[:previous_url] == survey_summary_url(survey)
+        elsif session[:previous_url] == survey_summary_url(survey)
+          next_section = section(survey, "BuildingWall")
+          delete_not_relevant_info(current_section: building_height.section, next_section: next_section)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingWall")

--- a/app/controllers/surveys/building_ownerships_controller.rb
+++ b/app/controllers/surveys/building_ownerships_controller.rb
@@ -33,7 +33,10 @@ module Surveys
         if before_update == "i_am_not_associated_with_this_building" && building_ownership.ownership_status != "i_am_not_associated_with_this_building"
           next_section = section(survey, "BuildingStatus")
           redirect_to next_survey_section(current_section: building_ownership.section, survey: survey, next_section: next_section)
-        elsif session[:previous_url] == survey_summary_url(survey)
+        elsif
+          session[:previous_url] == survey_summary_url(survey)
+          next_section = section(survey, "BuildingStatus")
+          delete_not_relevant_info(current_section: building_ownership.section, next_section: next_section)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingStatus")

--- a/app/controllers/surveys/building_statuses_controller.rb
+++ b/app/controllers/surveys/building_statuses_controller.rb
@@ -41,6 +41,8 @@ module Surveys
           redirect_to next_survey_section(current_section: building_status.section, survey: survey, next_section: next_section)
         elsif
           session[:previous_url] == survey_summary_url(survey)
+          next_section = section(survey, "BuildingTenure")
+          delete_not_relevant_info(current_section: building_status.section, next_section: next_section)
           redirect_to survey_summary_path(survey)
         else
           next_section = section(survey, "BuildingTenure")

--- a/app/models/survey_sequence_router.rb
+++ b/app/models/survey_sequence_router.rb
@@ -16,8 +16,9 @@ class SurveySequenceRouter
     survey.sections.find_by(content_type: "BuildingWall").content_id
   end
 
+
   def next_section_for(current_section, next_section)
-    return survey_summary_path(survey) if current_section.should_terminate_survey?
+    return survey_summary_path(survey)   if current_section.should_terminate_survey?
 
     case current_section.class.name
     when "BuildingOwnership"


### PR DESCRIPTION
why: 
when building owner changes their answer, ex from existing to demolished following sections should be deleted from the survey and not to be displayed on summary page

any issues
no 

link: 
https://trello.com/c/z8FlKb1o/73-as-a-building-owner-if-i-change-my-answer-the-other-answers-that-are-not-relevant-are-not-submitted