### PR TITLE
Add validation for balcony and solar materials

### DIFF
--- a/app/controllers/surveys/external_walls_material_details_controller.rb
+++ b/app/controllers/surveys/external_walls_material_details_controller.rb
@@ -13,10 +13,16 @@ module Surveys
     end
 
     def create
-      material_detail_list = MaterialDetailList.new detail_list_params
-      if material_detail_list.save
+      @material_detail_list = MaterialDetailList.new detail_list_params
+
+      if @material_detail_list.save
         next_section = nil
         redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey, next_section: next_section)
+      else
+        @survey = survey
+        @previous_section = section(@survey, "BuildingExternalWallStructure")
+        @external_wall_structure = external_wall_structure
+        render :new
       end
     end
 
@@ -29,9 +35,16 @@ module Surveys
     end
 
     def update
-      if material_detail_list.update detail_list_params
+      @material_detail_list = material_detail_list
+      if @material_detail_list.update detail_list_params
         next_section = nil
         redirect_to next_survey_section(current_section: external_wall_structure.section, survey: survey, next_section: next_section)
+      else
+        @survey = survey
+        @previous_section = section(@survey, "BuildingExternalWallStructure")
+        @external_wall_structure = external_wall_structure
+        @material_detail_list = @material_detail_list
+        render :edit
       end
     end
 

--- a/app/models/material_detail_list.rb
+++ b/app/models/material_detail_list.rb
@@ -2,8 +2,52 @@ class MaterialDetailList < ApplicationRecord
   belongs_to :building_external_wall_structure
 
   validates :external_structure_name, presence: true, inclusion: { in: %w(balcony solar_shading) }
+  validates :other_primary_material_details, presence: { message: "can't be blank. Please fill in the other details text field." }, if: -> { has_other_primary_material? }
+  validates :other_floor_material_details, presence: { message: "can't be blank. Please fill in the floor details text field." }, if: -> { has_other_floor_material? }
+  validates :other_railing_material_details, presence: { message: "can't be blank. Please fill in the railing details text field." }, if: -> { has_other_railing_material? }
+
+  validate :has_materials_for_external_structures
+  validate :has_one_primary_material_for_balcony, if: -> { external_structure_name == "balcony" }
 
   def reply
     "#{external_structure_name.classify}MaterialListReply".constantize.new(self).render
   end
+
+  private
+    def has_materials_for_external_structures
+      if has_timber_or_wood_primary_material ||
+        has_timber_or_wood_floor_material ||
+        has_timber_or_wood_railing_material ||
+        has_glass_primary_material ||
+        has_glass_floor_material ||
+        has_glass_railing_material ||
+        has_metal_primary_material ||
+        has_metal_floor_material ||
+        has_metal_railing_material ||
+        has_concrete_primary_material ||
+        has_concrete_floor_material ||
+        has_concrete_railing_material ||
+        has_unknown_primary_material ||
+        has_unknown_floor_material ||
+        has_unknown_railing_material ||
+        has_other_primary_material ||
+        has_other_floor_material ||
+        has_other_railing_material
+      else
+        errors.add(:base, "Please select at least one option")
+      end
+    end
+
+    def has_one_primary_material_for_balcony
+      material_count = [
+        has_timber_or_wood_primary_material,
+        has_glass_primary_material?,
+        has_metal_primary_material?,
+        has_concrete_primary_material?,
+        has_unknown_primary_material?,
+        has_other_primary_material?].count(&:itself)
+      if material_count > 1
+        errors.add(:primary_materials, ": Single select. Please select only one option for balcony primary materials")
+      end
+    end
 end

--- a/app/views/surveys/external_walls_material_details/_balcony_details_form.html.erb
+++ b/app/views/surveys/external_walls_material_details/_balcony_details_form.html.erb
@@ -1,290 +1,313 @@
 <%= render 'application/back_link', chosen_path: edit_survey_building_external_wall_structure_path(@survey.id, @previous_section.content_id) %>
-<div>
-  <%= form_with model: [@survey, @external_wall_structure, @material_detail_list] do |form_builder| %>
-    <%= hidden_field_tag :required_detail, :balcony %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">
-            Balcony materials
-          </h1>
-        </legend>
-        <div class="govuk-form-group">
-        <div class="govuk-checkboxes" data-materials="balcony-primary" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
-            <div class="govuk-hint">
-              What material is the primary structure of the balcony made from?
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_timber_or_wood_primary_material,
-                {class: "govuk-checkboxes__input"},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_timber_or_wood_primary_material,
-            "Timber or wood",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_glass_primary_material,
-                {class: "govuk-checkboxes__input"},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_glass_primary_material,
-            "Glass",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_metal_primary_material,
-                {class: "govuk-checkboxes__input"},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_metal_primary_material,
-            "Metal",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_concrete_primary_material,
-                {class: "govuk-checkboxes__input"},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_concrete_primary_material,
-            "Concrete",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_unknown_primary_material,
-                {class: "govuk-checkboxes__input"},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_unknown_primary_material,
-            "Do not know",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
-                :has_other_primary_material,
-                {class: "govuk-checkboxes__input", data: { action: "detail#toggle" }},
-                "true",
-                "false"
-              ) %>
-            <%= form_builder.label(
-            :has_other_primary_material,
-            "Other",
-            class: "govuk-label govuk-checkboxes__label"
-          ) %>
-            </div>
-            <div class="govuk-form-group <%= form_builder.object.has_other_primary_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
-              <%= form_builder.label :other_primary_material_details, "Please list other promary materials for the balconies", class: "govuk-label" %>
-              <div class="govuk-hint">
-                List any other primary materials for the balconies, separated by commas.
-              </div>
-              <%= form_builder.text_field :other_primary_material_details, class: "govuk-input govuk-input--width-20" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div>
+      <%= form_with model: [@survey, @external_wall_structure, @material_detail_list], local:true do |form_builder| %>
+        <%= hidden_field_tag :required_detail, :balcony %>
+        <% if @material_detail_list.errors.any? %>
+          <div class="govuk-error-summary">
+            <h2 class="govuk-error-summary__title">
+              There was a problem with your survey
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list">
+                <% @material_detail_list.errors.full_messages.each do |msg| %>
+                  <li>
+                    <span class="govuk-error-message">
+                      <%= msg %>
+                    </span>
+                  </li>
+                <% end %>
+              </ul>
             </div>
           </div>
-        </div>
+        <% end %>
         <div class="govuk-form-group">
-        <div class="govuk-checkboxes" data-materials="balcony-floors" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
-            <div class="govuk-hint">
-              What materials are the balcony floors made from?
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Balcony materials
+              </h1>
+            </legend>
+            <div class="govuk-form-group<%= "govuk-form-group--error" if @material_detail_list.errors[:primary_materials].any? %>">
+              <div class="govuk-checkboxes" data-materials="balcony-primary" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
+                <div class="govuk-hint">
+                  What material is the primary structure of the balcony made from?
+                </div>
+                <div class="govuk-hint">
+                  Please select one.
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_timber_or_wood_primary_material,
+                    {class: "govuk-radios__input"},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                :has_timber_or_wood_primary_material,
+                "Timber or wood",
+                class: "govuk-label govuk-radios__label"
+              ) %>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_glass_primary_material,
+                    {class: "govuk-radios__input"},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                :has_glass_primary_material,
+                "Glass",
+                class: "govuk-label govuk-radios__label"
+              ) %>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_metal_primary_material,
+                    {class: "govuk-radios__input"},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                :has_metal_primary_material,
+                "Metal",
+                class: "govuk-label govuk-radios__label"
+              ) %>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_concrete_primary_material,
+                    {class: "govuk-radios__input"},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                :has_concrete_primary_material,
+                "Concrete",
+                class: "govuk-label govuk-radios__label"
+              ) %>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_unknown_primary_material,
+                    {class: "govuk-radios__input"},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                :has_unknown_primary_material,
+                "Do not know",
+                class: "govuk-label govuk-radios__label"
+              ) %>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <%= form_builder.check_box(
+                    :has_other_primary_material,
+                    {class: "govuk-checkboxes__input", data: { action: "detail#toggle" }},
+                    "true",
+                    "false"
+                  ) %>
+                  <%= form_builder.label(
+                    :has_other_primary_material,
+                    "Other",
+                    class: "govuk-label govuk-checkboxes__label"
+                  ) %>
+                </div>
+                <div class="<%= "govuk-form-group--error govuk-!-margin-2" if @material_detail_list.errors[:other_primary_material_details].any? %>" >
+                  <div class="govuk-form-group <%= form_builder.object.has_other_floor_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
+                    <%= form_builder.label :other_primary_material_details, "Please list other primary materials for the balcony. Separate these by commas.", class: "govuk-hint" %>
+                    <%= form_builder.text_field :other_primary_material_details, class: "govuk-input govuk-input--width-20" %>
+                  </div>
+                </div>
+              </div>
             </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+            <div class="govuk-form-group">
+            <div class="govuk-radios" data-materials="balcony-floors" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
+              <div class="govuk-hint">
+                What materials are the balcony floors made from?
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_timber_or_wood_floor_material,
                 {class: "govuk-checkboxes__input"},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_timber_or_wood_floor_material,
               "Timber or wood",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_glass_floor_material,
                 {class: "govuk-checkboxes__input"},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_glass_floor_material,
               "Glass",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_metal_floor_material,
                 {class: "govuk-checkboxes__input"},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_metal_floor_material,
               "Metal",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_concrete_floor_material,
                 {class: "govuk-checkboxes__input"},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_concrete_floor_material,
               "Concrete",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_unknown_floor_material,
                 {class: "govuk-checkboxes__input"},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_unknown_floor_material,
               "Do not know",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
                 :has_other_floor_material,
                 {class: "govuk-checkboxes__input", data: { action: "detail#toggle" }},
                 "true",
                 "false"
               ) %>
-            <%= form_builder.label(
+                <%= form_builder.label(
               :has_other_floor_material,
               "Other",
               class: "govuk-label govuk-checkboxes__label"
             ) %>
-            </div>
-            <div class="govuk-form-group <%= form_builder.object.has_other_floor_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
-              <%= form_builder.label :other_floor_material_details, "Please list other floor materials for the balconies", class: "govuk-label" %>
-              <div class="govuk-hint">
-                List any other floor materials for the balconies, separated by commas.
               </div>
-              <%= form_builder.text_field :other_floor_material_details, class: "govuk-input govuk-input--width-20" %>
+              <div class="<%= "govuk-form-group--error govuk-!-margin-2" if @material_detail_list.errors[:other_floor_material_details].any? %>" >
+                <div class="govuk-form-group <%= form_builder.object.has_other_floor_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
+                  <%= form_builder.label :other_floor_material_details, "Please list other floor materials for the balcony. Separate these by commas.", class: "govuk-hint" %>
+                  <%= form_builder.text_field :other_floor_material_details, class: "govuk-input govuk-input--width-20" %>
+                </div>
+              </div>
+          </div>
+          <div class="govuk-form-group">
+          <div class="govuk-checkboxes" data-materials="balcony-railings" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
+            <div class="govuk-hint">
+              What materials are the balcony railings/balustrades made from?
             </div>
-          </div>
-        </div>
-        <div class="govuk-checkboxes" data-materials="balcony-railings" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
-          <div class="govuk-hint">
-            What materials are the balcony railings/balustrades made from?
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_timber_or_wood_railing_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_timber_or_wood_railing_material,
             "Timber or wood",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_glass_railing_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_glass_railing_material,
             "Glass",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_metal_railing_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_metal_railing_material,
             "Metal",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_concrete_railing_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_concrete_railing_material,
             "Concrete",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_unknown_railing_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_unknown_railing_material,
             "Do not know",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= form_builder.check_box(
               :has_other_railing_material,
               {class: "govuk-checkboxes__input", data: { action: "detail#toggle" }},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+              <%= form_builder.label(
             :has_other_railing_material,
             "Other",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-form-group <%= form_builder.object.has_other_railing_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
-            <%= form_builder.label :other_railing_material_details, "Please list other railing/balustrade material for the balconies", class: "govuk-label" %>
-            <div class="govuk-hint">
-              List any other railing/balustrade materials for the balconies, separated by commas.
             </div>
-            <%= form_builder.text_field :other_railing_material_details, class: "govuk-input govuk-input--width-20" %>
+            <div class="<%= "govuk-form-group--error govuk-!-margin-2" if @material_detail_list.errors[:other_railing_material_details].any? %>" >
+              <div class="govuk-form-group <%= form_builder.object.has_other_railing_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
+                <%= form_builder.label :other_railing_material_details, "Please list other railing/balustrade materials for the balcony. Separate these by commas.", class: "govuk-hint" %>
+                <%= form_builder.text_field :other_railing_material_details, class: "govuk-input govuk-input--width-20" %>
+              </div>
+            </div>
           </div>
         </div>
-      </fieldset>
+        </fieldset>
+      </div>
+      <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
+    <% end %>
     </div>
-    <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/surveys/external_walls_material_details/_solar_shading_details_form.html.erb
+++ b/app/views/surveys/external_walls_material_details/_solar_shading_details_form.html.erb
@@ -1,106 +1,127 @@
 <%= render 'application/back_link', chosen_path: edit_survey_building_external_wall_structure_path(@survey.id, @previous_section.content_id) %>
-<div>
-  <%= form_with model: [@survey, @external_wall_structure, @material_detail_list] do |form_builder| %>
-    <%= hidden_field_tag :required_detail, :solar_shading %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-          <h1 class="govuk-fieldset__heading">
-            Solar shading materials
-          </h1>
-        </legend>
-        <div class="govuk-checkboxes" data-materials="solar-shading-primary" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
-          <div class="govuk-hint">
-            What material is the solar shading made from?
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div>
+      <%= form_with model: [@survey, @external_wall_structure, @material_detail_list], local: true do |form_builder| %>
+        <%= hidden_field_tag :required_detail, :solar_shading %>
+        <% if @material_detail_list.errors.any? %>
+          <div class="govuk-error-summary">
+            <h2 class="govuk-error-summary__title">
+              There was a problem with your survey
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list">
+                <% @material_detail_list.errors.full_messages.each do |msg| %>
+                  <li>
+                    <span class="govuk-error-message">
+                      <%= msg %>
+                    </span>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+        <% end %>
+        <div class="govuk-form-group<%= "govuk-form-group--error" if @material_detail_list.errors.any? %>">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Solar shading materials
+              </h1>
+            </legend>
+            <div class="govuk-checkboxes" data-materials="solar-shading-primary" data-controller="detail" data-detail-toggle-class="govuk-visually-hidden">
+              <div class="govuk-hint">
+                What material is the solar shading made from?
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_timber_or_wood_primary_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_timber_or_wood_primary_material,
             "Timber or wood",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_glass_primary_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_glass_primary_material,
             "Glass",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_metal_primary_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_metal_primary_material,
             "Metal",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_concrete_primary_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_concrete_primary_material,
             "Concrete",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_unknown_primary_material,
               {class: "govuk-checkboxes__input"},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_unknown_primary_material,
             "Do not know",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <%= form_builder.check_box(
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= form_builder.check_box(
               :has_other_primary_material,
               {class: "govuk-checkboxes__input", data: { action: "detail#toggle" }},
               "true",
               "false"
             ) %>
-          <%= form_builder.label(
+                <%= form_builder.label(
             :has_other_primary_material,
             "Other",
             class: "govuk-label govuk-checkboxes__label"
           ) %>
-          </div>
-          <div class="govuk-form-group <%= form_builder.object.has_other_primary_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
-            <%= form_builder.label :other_primary_material_details, "Please list other materials for the solar shading", class: "govuk-label" %>
-            <div class="govuk-hint">
-              List any other external structures, separated by commas.
+              </div>
+              <div class="<%= "govuk-form-group--error govuk-!-margin-2" if @material_detail_list.errors[:other_primary_material_details].any? %>">
+                <div class="govuk-form-group <%= form_builder.object.has_other_primary_material? ? nil : "govuk-visually-hidden" %>" data-target="detail.input">
+                  <%= form_builder.label :other_primary_material_details, "Please list other materials for the solar shading, separated by commas", class: "govuk-label" %>
+                  <%= form_builder.text_field :other_primary_material_details, class: "govuk-input govuk-input--width-20" %>
+                </div>
+              </div>
             </div>
-            <%= form_builder.text_field :other_primary_material_details, class: "govuk-input govuk-input--width-20" %>
           </div>
-        </div>
+        </fieldset>
+        <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
+      <% end %>
     </div>
-      </fieldset>
-      <%= form_builder.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
-    <% end %>
+  </div>
 </div>

--- a/spec/factories/material_detail_lists.rb
+++ b/spec/factories/material_detail_lists.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :material_detail_list do
-    building_external_wall_structure { nil }
-    external_structure_name { "MyString" }
+    association :building_external_wall_structure
   end
 end

--- a/spec/models/building_external_wall_structure_spec.rb
+++ b/spec/models/building_external_wall_structure_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe BuildingExternalWallStructure, "#complete?" do
       )
       create(
         :material_detail_list,
+        has_concrete_primary_material: true,
         external_structure_name: "balcony",
         building_external_wall_structure: external_walls
       )
@@ -109,6 +110,7 @@ RSpec.describe BuildingExternalWallStructure, "#complete?" do
       )
       create(
         :material_detail_list,
+        has_concrete_primary_material: true,
         external_structure_name: "solar_shading",
         building_external_wall_structure: external_walls
       )
@@ -141,10 +143,12 @@ RSpec.describe BuildingExternalWallStructure, "#complete?" do
       create(
         :material_detail_list,
         external_structure_name: "balcony",
+        has_metal_primary_material: true,
         building_external_wall_structure: external_walls
       )
       create(
         :material_detail_list,
+        has_concrete_primary_material: true,
         external_structure_name: "solar_shading",
         building_external_wall_structure: external_walls
       )
@@ -176,6 +180,7 @@ RSpec.describe BuildingExternalWallStructure, "#next_required_detail" do
       )
       create(
         :material_detail_list,
+        has_concrete_primary_material: true,
         external_structure_name: "balcony",
         building_external_wall_structure: external_wall
       )
@@ -205,6 +210,7 @@ RSpec.describe BuildingExternalWallStructure, "#next_required_detail" do
       )
       create(
         :material_detail_list,
+        has_concrete_primary_material: true,
         external_structure_name: "solar_shading",
         building_external_wall_structure: external_wall
       )

--- a/spec/system/building_manager_views_survey_reply_summary_spec.rb
+++ b/spec/system/building_manager_views_survey_reply_summary_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "Building manager views survey reply summary" do
       building_external_wall_structure: external_wall_structure,
       external_structure_name: "balcony",
       has_timber_or_wood_primary_material: true,
-      has_glass_primary_material: true,
       has_concrete_floor_material: true,
       has_metal_railing_material: true
     )
@@ -84,14 +83,8 @@ RSpec.describe "Building manager views survey reply summary" do
     click_on "Continue"
 
     expect_building_external_wall_structure_to_be_displayed_as "Solar shading"
-    expect_balcony_structure_to_be_displayed_as "Primary materials: Timber or wood, Glass Floor materials: Concrete Railings/balustrades: Metal"
-    expect_solar_shading_structure_to_be_displayed_as "Glass, Metal"
-
-    within(balcony_structure_row) { click_on "Change" }
-    within(balcony_primary_materials_row) { uncheck "Glass" }
-    click_on "Continue"
-
     expect_balcony_structure_to_be_displayed_as "Primary materials: Timber or wood Floor materials: Concrete Railings/balustrades: Metal"
+    expect_solar_shading_structure_to_be_displayed_as "Glass, Metal"
 
     within(solar_shading_structure_row) { click_on "Change" }
     within(solar_shading_floor_materials_row) { check "Concrete" }
@@ -126,7 +119,6 @@ RSpec.describe "Building manager views survey reply summary" do
       building_external_wall_structure: external_wall_structure,
       external_structure_name: "balcony",
       has_timber_or_wood_primary_material: true,
-      has_glass_primary_material: true,
       has_concrete_floor_material: true,
       has_metal_railing_material: true
     )

--- a/spec/system/surveys/external_wall_structures_section_spec.rb
+++ b/spec/system/surveys/external_wall_structures_section_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "External wall structures section" do
 
     within(balcony_primary_material_section) do
       check "Timber or wood"
-      check "Metal"
     end
 
     within(balcony_floor_material_section) do
@@ -30,6 +29,7 @@ RSpec.describe "External wall structures section" do
       check "Metal"
       check "Do not know"
       check "Other"
+      fill_in "Please list other railing/balustrade materials for the balcony. Separate these by commas.", with: "Praline truffles"
     end
 
     click_on "Continue"
@@ -39,6 +39,7 @@ RSpec.describe "External wall structures section" do
     check "Metal"
     check "Do not know"
     check "Other"
+    fill_in "Please list other materials for the solar shading, separated by commas", with: "Minky whales"
 
     click_on "Continue"
 


### PR DESCRIPTION
After discussion with Claudia, we agreed to drop the idea for radio buttons - while the first ones are styled as radios they work as checkboxes - added a validation to ask that no more than one is selected.
balconies:
![image](https://user-images.githubusercontent.com/9452321/94034370-d99ddc80-fdb9-11ea-83b5-c16bf72548a0.png)

solar shading:
![image](https://user-images.githubusercontent.com/9452321/94034543-0eaa2f00-fdba-11ea-89f3-d0234effea32.png)

and
![image](https://user-images.githubusercontent.com/9452321/94034877-66489a80-fdba-11ea-8c4d-18ad1553e1b1.png)

stories:
https://trello.com/c/BWohczbR/136-validation-html-updates-to-solar-shading-materials-add-validation-for-content-remove-second-line-of-content

https://trello.com/c/gw2gbBHF/137-validation-and-html-changes-to-balcony-details-section