### PR TITLE
Add validation to external facing materials

### DIFF
--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -4,6 +4,7 @@ class Material < ApplicationRecord
   has_one :percentage, dependent: :destroy
 
   validates :name, presence: true, allow_blank: false
+  validates :comments, presence: true
 
   def should_terminate_survey?
     false

--- a/app/views/surveys/materials/_form.html.erb
+++ b/app/views/surveys/materials/_form.html.erb
@@ -1,4 +1,20 @@
-<div class="govuk-form-group">
+<% if !@error.nil? %>
+  <div class="govuk-error-summary">
+    <h2 class="govuk-error-summary__title">
+      There was a problem with your survey
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list">
+        <li>
+          <span class="govuk-error-message">
+            <%= @error %>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>
+<div class="govuk-form-group <%= " govuk-form-group--error" if !@error.nil? %>">
   <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
@@ -9,18 +25,29 @@
       Select all that apply
     </div>
     <div class="govuk-checkboxes">
-      <%= f.collection_check_boxes(:materials, @options_for_materials, :itself, :itself) do |b| %>
+      <%= f.collection_check_boxes(:materials, @options_for_materials, :itself, :itself, include_hidden: false) do |b| %>
         <div class="govuk-checkboxes__item">
           <%= b.check_box(class: 'govuk-checkboxes__input', checked: @building_wall.materials.find_by(name: b.value) ? true : false) %>
           <%= b.label(class: 'govuk-label govuk-checkboxes__label') %>
         </div>
       <% end %>
-      <div class="govuk-form-group govuk-visually-hidden" id="other_material_details" %>
-        <%= f.label :details, "Please describe the selected material", class: "govuk-label" %>
-        <%= f.text_field :details, class: "govuk-input govuk-input--width-20", value: @other_material ? @other_material : '' %>
-      </div>
-      <br>
-      <%= f.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>
     </div>
   </fieldset>
 </div>
+<div class="govuk-form-group govuk-visually-hidden" id="other_material_details" %>
+  <%= f.label :details, "Please describe the selected material", class: "govuk-label" %>
+  <%= f.text_field :details, class: "govuk-input govuk-input--width-20", value: @other_material ? @other_material : '' %>
+</div>
+<br>
+<div class="govuk-form-group hidden <%= " govuk-form-group--error" if !@error.nil? %>" data-target="building-status.details">
+  <h2 class="govuk-label-wrapper">
+    <label class="govuk-label govuk-label--m" for="comments">
+   Please provide any further details you may have about any of the material(s) identified. Information could include the manufacturer, product name or reaction to fire classification
+    </label>
+  </h2>
+  <div id="comments" class="govuk-hint">
+    Do not include personal or financial information, like your National Insurance number or credit card details.
+  </div>
+  <textarea class="govuk-textarea" id="comments" name="comments" rows="5" aria-describedby="more-detail-hint"></textarea>
+</div>
+<%= f.submit "Continue", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/surveys/materials/edit.html.erb
+++ b/app/views/surveys/materials/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render 'application/back_link', chosen_path: edit_survey_building_height_path(@survey.id, @previous_section.content_id) %>
 <div data-controller="building-status">
-  <%= form_with model: @materials, url: survey_building_wall_material_edit_path, method: :patch do |f| %>
+  <%= form_with model: @materials, url: survey_building_wall_material_edit_path, method: :patch, local: true do |f| %>
     <%= render "form", f:f %>
   <% end %>
 </div>

--- a/app/views/surveys/materials/new.html.erb
+++ b/app/views/surveys/materials/new.html.erb
@@ -1,6 +1,6 @@
 <%= render 'application/back_link', chosen_path: edit_survey_building_height_path(@survey.id, @previous_section.content_id) %>
   <div data-controller="building-status">
-    <%= form_with model: @materials, url: survey_building_wall_materials_path do |f| %>
+    <%= form_with model: @materials, url: survey_building_wall_materials_path, local: true do |f| %>
       <%= render "form", f:f %>
     <% end %>
   </div>

--- a/db/migrate/20200922121219_add_comments_to_materials.rb
+++ b/db/migrate/20200922121219_add_comments_to_materials.rb
@@ -1,0 +1,5 @@
+class AddCommentsToMaterials < ActiveRecord::Migration[6.0]
+  def change
+    add_column :materials, :comments, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_16_165118) do
+ActiveRecord::Schema.define(version: 2020_09_22_121219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(version: 2020_09_16_165118) do
     t.text "details"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "comments"
     t.index ["building_wall_id"], name: "index_materials_on_building_wall_id"
   end
 

--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
       "Plastic"
     ]
     name { materials.sample }
+    comments { "potato" }
   end
 end

--- a/spec/features/building_manager_journey_spec.rb
+++ b/spec/features/building_manager_journey_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "Building manager functionality" do
       check "Brick slips", visible: false
       check "Other", visible: false
       fill_in "Please describe the selected material", with: "Potatoes"
+      fill_in "Please provide any further details you may have about any of the material(s) identified. Information could include the manufacturer, product name or reaction to fire classification", with: "Potatoes"
 
       click_button "Continue"
 

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Material, "validation" do
+  it "is invalid if comments are not provided" do
+    material = Material.create(name: "Brick", building_wall_id: 1, comments: "")
+
+
+    expect(material).not_to be_valid
+    expect(material.errors.added?(:comments, "can't be blank")).to be_truthy
+  end
+end

--- a/spec/models/percentage_spec.rb
+++ b/spec/models/percentage_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-RSpec.describe BuildingStatus, "validation" do
-    it "is invalid if material_percentage is not present" do
-      percentage = Percentage.create(material_id: 1, material_percentage: "")
+RSpec.describe Percentage, "validation" do
+  it "is invalid if material_percentage is not present" do
+    percentage = Percentage.create(material_id: 1, material_percentage: "")
 
 
-      expect(percentage).not_to be_valid
-      expect(percentage.errors.added?(:material_percentage, "can't be blank")).to be_truthy
-    end
+    expect(percentage).not_to be_valid
+    expect(percentage.errors.added?(:material_percentage, "can't be blank")).to be_truthy
   end
+end

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -139,8 +139,9 @@ RSpec.describe "Building manager views survey reply summary" do
       check 'Brick slips'
 
       uncheck 'Other'
-      check 'Other'
+      check 'Other', visible: false
       fill_in "Please describe the selected material", with: "Candy canes"
+      fill_in "Please provide any further details you may have about any of the material(s) identified. Information could include the manufacturer, product name or reaction to fire classification", with: "Potatoes"
       click_on "Continue"
 
       fill_in "Brick slips", with: "40"
@@ -235,7 +236,7 @@ RSpec.describe "Building manager views survey reply summary" do
       create :section, content: building_height, survey: survey
       building_wall = create :building_wall, survey: survey
       create :section, content: building_wall, survey: survey
-      material = create :material, building_wall: building_wall, name: "Glass"
+      material = create :material, building_wall: building_wall, name: "Glass", comments: "potato"
 
       visit new_survey_building_wall_insulation_path(survey_id: survey.id, building_wall_id: building_wall.id)
 
@@ -260,6 +261,31 @@ RSpec.describe "Building manager views survey reply summary" do
       expect(page).to have_text "Please select at least one option"
     end
 
+    it "displays an error if no value was provided for external facing materials" do
+      survey = create(:survey)
+      building_height = create(:building_height, higher_than_18_meters: true, survey: survey)
+      create :section, content: building_height, survey: survey
+      visit survey_building_walls_path(survey)
+      click_on "Continue"
+      click_on "Continue"
+
+      expect(page).to have_text "There was a problem with your survey"
+      expect(page).to have_text "Please choose one of the options provided and leave a comment"
+    end
+
+    it "displays an error if no comments were provided for external facing materials" do
+      survey = create(:survey)
+      building_height = create(:building_height, higher_than_18_meters: true, survey: survey)
+      create :section, content: building_height, survey: survey
+      visit survey_building_walls_path(survey)
+      click_on "Continue"
+      check "Glass"
+      click_on "Continue"
+
+      expect(page).to have_text "There was a problem with your survey"
+      expect(page).to have_text "Please choose one of the options provided and leave a comment"
+    end
+
 
     it "displays an error if no value was provided for percentages" do
       survey = create(:survey)
@@ -269,6 +295,7 @@ RSpec.describe "Building manager views survey reply summary" do
       click_on "Continue"
       check "Glass"
       check "Metal sheet panels"
+      fill_in "Please provide any further details you may have about any of the material(s) identified. Information could include the manufacturer, product name or reaction to fire classification", with: "Potatoes"
       click_on "Continue"
       click_on "Continue"
 
@@ -284,6 +311,7 @@ RSpec.describe "Building manager views survey reply summary" do
       click_on "Continue"
       check "Glass"
       check "Metal sheet panels"
+      fill_in "Please provide any further details you may have about any of the material(s) identified. Information could include the manufacturer, product name or reaction to fire classification", with: "Potatoes"
       click_on "Continue"
       fill_in "Glass", with: 500
       fill_in "Metal sheet panels", with: 70

--- a/spec/system/building_manager_views_survey_reply_summary_spec.rb
+++ b/spec/system/building_manager_views_survey_reply_summary_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "Building manager views survey reply summary" do
     create :section, content: building_height, survey: survey
     building_wall = create :building_wall, survey: survey
     create :section, content: building_wall, survey: survey
-    material_one = create :material, building_wall: building_wall, name: "Brick"
+    material_one = create :material, building_wall: building_wall, name: "Brick", comments: "potato"
     percentage_one = create :percentage, material: material_one
     insulation_one = create :insulation, insulation_material: "Pompons", material: material_one, insulation_details: "glass turkeys"
-    material_two = create :material, building_wall: building_wall, name: "Other", details: "Fudge"
+    material_two = create :material, building_wall: building_wall, name: "Other", details: "Fudge", comments: "potato"
     percentage_two = create :percentage, material: material_two
     insulation_two = create :insulation, material: material_two, insulation_material: "Glass", insulation_details: "porcelain chickens"
 
@@ -112,10 +112,10 @@ RSpec.describe "Building manager views survey reply summary" do
     create :section, content: building_height, survey: survey
     building_wall = create :building_wall, survey: survey
     create :section, content: building_wall, survey: survey
-    material_one = create :material, building_wall: building_wall, name: "Brick"
+    material_one = create :material, building_wall: building_wall, name: "Brick", comments: "potato"
     percentage_one = create :percentage, material: material_one
     insulation_one = create :insulation, insulation_material: "Pompons", material: material_one, insulation_details: "porcelain chickens"
-    material_two = create :material, building_wall: building_wall, name: "Other", details: "Fudge"
+    material_two = create :material, building_wall: building_wall, name: "Other", details: "Fudge", comments: "potato"
     percentage_two = create :percentage, material: material_two
     insulation_two = create :insulation, material: material_two, insulation_material: "Glass", insulation_details: "porcelain chickens"
 


### PR DESCRIPTION
Why?
1- building owner needs to choose at least 1 option
2-there were design updates, had to add comment box, which is mandatory to fill in

What?
Updated materials_controller
integrated new logic to edit and updated methods 
Updated tests
created new tests for validation

Link to story:
https://trello.com/c/gwSG7lrh/140-validation-and-html-update-to-external-facing-materials-comment-box