### PR TITLE
Allow admin to send email link to survey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy the contents of this file to .env and adjust the values accordingly
+
+NOTIFY_API_KEY="CHANGEME"
+NOTIFY_EMAIL_TEMPLATE_ID="CHANGEME"
+NOTIFY_CALLBACK_TOKEN="CHANGEME"
+APPLICATION_HOST="CHANGEME"

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'devise'
+gem 'delayed_job_active_record'
+gem 'notifications-ruby-client'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -36,6 +38,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'rubocop'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -85,6 +90,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -99,6 +108,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jwt (2.2.2)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -118,6 +128,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -266,10 +278,13 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  delayed_job_active_record
   devise
+  dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  notifications-ruby-client
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.1)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
+worker: rake jobs:work

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 app: bin/rails server
 assets: bin/webpack-dev-server
+worker: rake jobs:work

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -1,0 +1,41 @@
+module Admin
+  class NotificationsController < AdminController
+    before_action :ensure_valid_notification_mean
+
+    def create
+      notification = building.notifications.create(
+        notification_mean: notification_mean,
+        state: :enqueued,
+        enqueued_at: DateTime.current
+      )
+
+      DeliverNotificationJob.perform_now notification
+
+      redirect_to admin_dashboard_path
+    end
+
+    private
+
+      def ensure_valid_notification_mean
+        unless valid_notification_mean_is_present?
+          redirect_to admin_dashboard_path and return
+        end
+      end
+
+      def building
+        Building.find params[:building_id]
+      end
+
+      def notification_mean
+        params[:mean_of_notification]
+      end
+
+      def valid_notification_mean_is_present?
+        valid_notification_means.include? notification_mean
+      end
+
+      def valid_notification_means
+        ["email", "letter"]
+      end
+  end
+end

--- a/app/controllers/callbacks/callbacks_controller.rb
+++ b/app/controllers/callbacks/callbacks_controller.rb
@@ -1,0 +1,13 @@
+module Callbacks
+  class CallbacksController < ApplicationController
+    before_action :authenticate_callback
+
+    protected
+
+      def authenticate_callback
+        authenticate_or_request_with_http_token do |token, _|
+          ActiveSupport::SecurityUtils.secure_compare token, ENV.fetch("NOTIFY_CALLBACK_TOKEN")
+        end
+      end
+  end
+end

--- a/app/controllers/callbacks/notification_statuses_controller.rb
+++ b/app/controllers/callbacks/notification_statuses_controller.rb
@@ -1,0 +1,33 @@
+module Callbacks
+  class NotificationStatusesController < CallbacksController
+    def create
+      case received_status
+      when "delivered"
+        notification.update!(
+          state: status_params.fetch(:status),
+          delivered_at: status_params.fetch(:completed_at),
+        )
+      when "temporary-failure" || "technical-failure"
+        notification.update! state: :enqueued
+        DeliverNotificationJob.perform_later notification
+      when "permanent-failure"
+        notification.update! state: :failed, failed_at: status_params.fetch(:completed_at)
+      end
+      head :created
+    end
+
+    private
+
+      def received_status
+        status_params.fetch(:status)
+      end
+
+      def status_params
+        params.slice :id, :reference, :to, :status, :sent_at, :completed_at
+      end
+
+      def notification
+        Notification.find status_params.fetch(:reference)
+      end
+  end
+end

--- a/app/jobs/deliver_notification_job.rb
+++ b/app/jobs/deliver_notification_job.rb
@@ -1,0 +1,16 @@
+class DeliverNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(notification)
+    client_response = NotificationClient.new(notification).deliver
+
+    if client_response
+      notification.update!(
+        notify_uri: client_response.uri,
+        notify_id: client_response.id,
+        state: :sent,
+        sent_at: DateTime.current,
+      )
+    end
+  end
+end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,7 +1,12 @@
 class Building < ApplicationRecord
   has_one :survey
+  has_many :notifications
 
   validates :uprn, presence: true, uniqueness: true
 
   scope :ordered_by_uprn, -> { order uprn: :asc }
+
+  def most_recent_notifications
+    Notification.most_recent_for_each_notification_mean(self)
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,48 @@
+class Notification < ApplicationRecord
+  belongs_to :building
+
+  validates :building, presence: true
+  validates :notification_mean, inclusion: { in: %w(email letter) }
+  validates :state, inclusion: { in: %w(created enqueued sent delivered failed) }
+
+  scope :for_building, -> (building) { where building: building }
+  scope :letter_notifications, -> { where notification_mean: "letter" }
+  scope :email_notifications, -> { where notification_mean: "email" }
+  scope :ordered_by_most_recent, -> { order created_at: :desc }
+
+  def self.most_recent_for_each_notification_mean(building)
+    [
+      for_building(building).email_notifications.ordered_by_most_recent.first,
+      for_building(building).letter_notifications.ordered_by_most_recent.first
+    ].compact
+  end
+
+  def summary
+    notification_state_summary
+  end
+
+  def deliverable_by_email?
+    notification_mean == "email"
+  end
+
+  def addressed_to
+    building.proprietor_email if deliverable_by_email?
+  end
+
+  private
+
+    def notification_state_summary
+      case state
+      when "created"
+        "#{notification_mean.capitalize} created on #{created_at.to_date}."
+      when "sent"
+        "#{notification_mean.capitalize} was sent on #{sent_at.to_date}."
+      when "delivered"
+        "#{notification_mean.capitalize} was delivered on #{delivered_at.to_date}."
+      when "failed"
+        "#{notification_mean.capitalize} cannot be delivered to the specified email address."
+      else
+        "No summary available"
+      end
+    end
+end

--- a/app/models/notification_client.rb
+++ b/app/models/notification_client.rb
@@ -1,0 +1,30 @@
+require "notifications/client"
+
+class NotificationClient
+  include Rails.application.routes.url_helpers
+
+  attr_reader :client, :notification
+
+  def initialize(notification)
+    @notification = notification
+    @client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+  end
+
+  def deliver
+    if notification.deliverable_by_email?
+      client.send_email(
+        email_address: notification.addressed_to,
+        template_id: ENV.fetch("NOTIFY_EMAIL_TEMPLATE_ID"),
+        reference: notification.id.to_s,
+        personalisation: {
+          full_name: notification.building.land_registry_proprietor_name,
+          building_name: notification.building.building_name,
+          address_line_1: notification.building.street,
+          postal_code: notification.building.postcode,
+          uprn: notification.building.uprn,
+          survey_link: get_started_url(uprn: notification.building.uprn, host: ENV.fetch("APPLICATION_HOST"))
+        }
+      )
+    end
+  end
+end

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -15,7 +15,9 @@
       <th scope="col" class="govuk-table__header">
         Proprietor address
       </th>
+      <th scope="col" class="govuk-table__header">Contacts</th>
       <th scope="col" class="govuk-table__header"></th>
+      <th scope="col" class="govuk-table__header">Actions</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -36,6 +38,21 @@
         </td>
         <td class="govuk-table__cell">
           <%= building.land_registry_proprietor_address %>
+        </td>
+        <td class="govuk-table__cell">
+          <% if building.proprietor_email %>
+            <%= link_to(
+              "Email survey link",
+              admin_building_notifications_path(building, mean_of_notification: :email),
+              method: :post,
+              remote: true
+            ) %>
+          <% end %>
+        </td>
+        <td class="govuk-table__cell">
+          <% building.most_recent_notifications.each do |notification| %>
+            <%= notification.summary %>
+          <% end %>
         </td>
         <td class="govuk-table__cell">
           <%= link_to "Edit", edit_admin_building_path(building) %>

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module SouthwarkBsp
     # the framework and any gems in your application.
 
     config.action_view.field_error_proc = ->(html_tag, instance) { html_tag }
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,14 @@ Rails.application.routes.draw do
     end
 
     resource :dashboard, only: [:show]
-    resources :buildings, only: [:new, :create, :edit, :update]
+    resources :buildings, only: [:new, :create, :edit, :update] do
+      resources :notifications, only: [:create]
+    end
     resources :bulk_imports, only: [:new, :create]
+  end
+
+  namespace :callbacks do
+    resources :notification_statuses, only: [:create], constraints: lambda { |request| request.format == :json }
   end
 
   get "new_survey", to: "surveys/start_surveys#new", as: :start_new_survey

--- a/db/migrate/20200918174338_create_notifications.rb
+++ b/db/migrate/20200918174338_create_notifications.rb
@@ -1,0 +1,17 @@
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notifications do |t|
+      t.references :building, null: false, foreign_key: true, on_delete: :cascade
+      t.string :notification_mean, null: false, default: ""
+      t.string :state, null: false, default: "created"
+      t.datetime :enqueued_at
+      t.datetime :sent_at
+      t.datetime :delivered_at
+      t.datetime :failed_at
+      t.string :notify_id
+      t.string :notify_uri
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200922144536_create_delayed_jobs.rb
+++ b/db/migrate/20200922144536_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_121219) do
+ActiveRecord::Schema.define(version: 2020_09_22_144536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -94,6 +94,21 @@ ActiveRecord::Schema.define(version: 2020_09_22_121219) do
     t.index ["uprn"], name: "index_buildings_on_uprn", unique: true
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "insulations", force: :cascade do |t|
     t.bigint "material_id", null: false
     t.string "insulation_material"
@@ -142,6 +157,21 @@ ActiveRecord::Schema.define(version: 2020_09_22_121219) do
     t.index ["building_wall_id"], name: "index_materials_on_building_wall_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "building_id", null: false
+    t.string "notification_mean", default: "", null: false
+    t.string "state", default: "created", null: false
+    t.datetime "enqueued_at"
+    t.datetime "sent_at"
+    t.datetime "delivered_at"
+    t.datetime "failed_at"
+    t.string "notify_id"
+    t.string "notify_uri"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["building_id"], name: "index_notifications_on_building_id"
+  end
+
   create_table "percentages", force: :cascade do |t|
     t.bigint "material_id", null: false
     t.integer "material_percentage"
@@ -188,6 +218,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_121219) do
   add_foreign_key "insulations", "materials", on_delete: :cascade
   add_foreign_key "material_detail_lists", "building_external_wall_structures"
   add_foreign_key "materials", "building_walls"
+  add_foreign_key "notifications", "buildings"
   add_foreign_key "percentages", "materials", on_delete: :cascade
   add_foreign_key "sections", "surveys"
   add_foreign_key "surveys", "buildings"

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :notification do
+    building { nil }
+
+    trait :email do
+      notification_mean { "email" }
+    end
+
+    trait :letter do
+      notification_mean { "letter" }
+    end
+
+    factory :email_notification, traits: [:email]
+    factory :letter_notification, traits: [:letter]
+  end
+end

--- a/spec/jobs/deliver_notification_job_spec.rb
+++ b/spec/jobs/deliver_notification_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe DeliverNotificationJob, "#perform" do
+  it "attempts to deliver the notification" do
+    notification = create :email_notification, building: create(:building)
+    notifier_spy = spy
+    expect(NotificationClient).to receive(:new).with(notification).and_return notifier_spy
+
+    DeliverNotificationJob.perform_now notification
+
+    expect(notifier_spy).to have_received :deliver
+  end
+
+  it "updates the notification with data from the notifier response if successful" do
+    notification = create :email_notification, state: "created", building: create(:building)
+    mock_notifier = double :notifier
+    mock_response = double :mock_response, uri: "http://someplace.fun/1", id: SecureRandom.uuid
+
+    allow(mock_notifier).to receive(:deliver).and_return mock_response
+    expect(NotificationClient).to receive(:new).with(notification).and_return mock_notifier
+
+    DeliverNotificationJob.perform_now notification
+
+    expect(notification.state).to eq "sent"
+    expect(notification.notify_uri).to eq mock_response.uri
+    expect(notification.notify_id).to eq mock_response.id
+    expect(notification.sent_at.to_date).to eq Date.today
+  end
+end

--- a/spec/models/notification_client_spec.rb
+++ b/spec/models/notification_client_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe NotificationClient, "#deliver" do
+  context "for an email notification" do
+    it "invokes the Notify client to send email with the correct data" do
+      building = build_stubbed(
+        :building,
+        proprietor_email: "owner@example.com",
+        land_registry_proprietor_name: "Zee Owner",
+        building_name: "ACME Tower",
+        street: "1 Infinite Loop",
+        postcode: "ACME B12",
+        uprn: "01234567890"
+      )
+      notification = build_stubbed :email_notification, building: building
+      notifier = NotificationClient.new notification
+      notify_client_spy = spy :notify_client_spy
+      allow(notifier).to receive(:client).and_return notify_client_spy
+
+      notifier.deliver
+
+      expect(notify_client_spy).to have_received(:send_email).with(
+        email_address: "owner@example.com",
+        template_id: ENV.fetch("NOTIFY_EMAIL_TEMPLATE_ID"),
+        reference: notification.id.to_s,
+        personalisation: {
+          full_name: "Zee Owner",
+          building_name: "ACME Tower",
+          address_line_1: "1 Infinite Loop",
+          postal_code: "ACME B12",
+          uprn: "01234567890",
+          survey_link: "http://#{ENV.fetch("APPLICATION_HOST")}/get_started?uprn=01234567890"
+        }
+      )
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,219 @@
+require "rails_helper"
+
+RSpec.describe Notification, "associations" do
+  it { is_expected.to belong_to :building }
+end
+
+RSpec.describe Notification, "validations" do
+  it { is_expected.to validate_presence_of :building }
+  it { is_expected.to validate_inclusion_of(:notification_mean).in_array %w(email letter) }
+  it { is_expected.to validate_inclusion_of(:state).in_array %w(created enqueued sent delivered failed) }
+end
+
+RSpec.describe Notification, ".for_building" do
+  it "returns notifications for a specific building" do
+    building = create :building
+    other_building = create :building
+    notification = create :email_notification, building: building
+    other_notification = create :email_notification, building: other_building
+
+    for_building = Notification.for_building building
+
+    expect(for_building).to eq [notification]
+    expect(for_building).not_to include(other_notification)
+  end
+end
+
+RSpec.describe Notification, ".letter_notifications" do
+  it "returns only letter notifications" do
+    letter_notification = create :letter_notification, building: create(:building)
+    email_notification = create :email_notification, building: create(:building)
+
+    letter_notifications = Notification.letter_notifications
+
+    expect(letter_notifications).to eq [letter_notification]
+    expect(letter_notifications).not_to include(email_notification)
+  end
+end
+
+RSpec.describe Notification, ".email_notifications" do
+  it "returns only email notifications" do
+    letter_notification = create :letter_notification, building: create(:building)
+    email_notification = create :email_notification, building: create(:building)
+
+    email_notifications = Notification.email_notifications
+
+    expect(email_notifications).to eq [email_notification]
+    expect(email_notifications).not_to include(letter_notification)
+  end
+end
+
+RSpec.describe Notification, ".ordered_by_most_recent" do
+  it "returns notifications ordered most recent to least recent" do
+    email_notification = create :email_notification, building: create(:building), created_at: Date.today
+    letter_notification = create :letter_notification, building: create(:building), created_at: Date.yesterday
+
+    ordered_notifications = Notification.ordered_by_most_recent
+
+    expect(ordered_notifications).to eq [email_notification, letter_notification]
+  end
+end
+
+RSpec.describe Notification, ".most_recent_for_each_notification_mean" do
+  it "returns the most recent email notification and the most recent letter notification" do
+    building = create(:building)
+    most_recent_email_notification = create :email_notification, building: building, created_at: Date.today
+    email_notification = create :letter_notification, building: building, created_at: Date.yesterday
+    other_email_notification = create :letter_notification, building: create(:building), created_at: Date.today
+    letter_notification = create :letter_notification, building: create(:building), created_at: Date.yesterday
+    most_recent_letter_notification = create :letter_notification, building: building, created_at: Date.today
+    other_letter_notification = create :letter_notification, building: create(:building), created_at: Date.today
+
+    most_recent_notifications = Notification.most_recent_for_each_notification_mean(building)
+
+    expect(most_recent_notifications).to eq [most_recent_email_notification, most_recent_letter_notification]
+  end
+end
+
+RSpec.describe Notification, ".most_recent_for_each_notification_mean" do
+  it "returns the most recent email notification and the most recent letter notification" do
+    building = create(:building)
+    most_recent_email_notification = create :email_notification, building: building, created_at: Date.today
+    email_notification = create :letter_notification, building: building, created_at: Date.yesterday
+    other_email_notification = create :letter_notification, building: create(:building), created_at: Date.today
+    letter_notification = create :letter_notification, building: create(:building), created_at: Date.yesterday
+    most_recent_letter_notification = create :letter_notification, building: building, created_at: Date.today
+    other_letter_notification = create :letter_notification, building: create(:building), created_at: Date.today
+
+    most_recent_notifications = Notification.most_recent_for_each_notification_mean(building)
+
+    expect(most_recent_notifications).to eq [most_recent_email_notification, most_recent_letter_notification]
+  end
+
+  it "returns only a letter notification if an email notification doesnt exist" do
+    building = create(:building)
+    letter_notification = create :letter_notification, building: create(:building), created_at: Date.yesterday
+    most_recent_letter_notification = create :letter_notification, building: building, created_at: Date.today
+
+    most_recent_notifications = Notification.most_recent_for_each_notification_mean(building)
+
+    expect(most_recent_notifications).to eq [most_recent_letter_notification]
+  end
+
+  it "returns only an email notification if a letter notification doesnt exist" do
+    building = create(:building)
+    most_recent_email_notification = create :email_notification, building: building, created_at: Date.today
+    other_email_notification = create :email_notification, building: building, created_at: Date.yesterday
+
+    most_recent_notifications = Notification.most_recent_for_each_notification_mean(building)
+
+    expect(most_recent_notifications).to eq [most_recent_email_notification]
+  end
+
+  it "returns an empty collection if no notifications exist" do
+    building = create :building
+
+    most_recent_notifications = Notification.most_recent_for_each_notification_mean building
+
+    expect(most_recent_notifications).to eq []
+  end
+end
+
+RSpec.describe Notification, "#summary" do
+  context "returns a description adequate to the notification mean and state" do
+    context "for an email notification with a state of created" do
+      it "indicates an email notification was created on a date" do
+        notification = build_stubbed :email_notification, state: "created"
+
+        summary = notification.summary
+
+        expect(summary).to eq "Email created on #{notification.created_at.to_date}."
+      end
+    end
+    context "for an email notification with a state of sent" do
+      it "indicates an email notification was sent" do
+        notification = build_stubbed :email_notification, state: "sent", sent_at: DateTime.current
+
+        summary = notification.summary
+
+        expect(summary).to eq "Email was sent on #{notification.sent_at.to_date}."
+      end
+    end
+    context "for an email notification with a state of delivered" do
+      it "indicates an email notification was delivered" do
+        notification = build_stubbed :email_notification, state: "delivered", delivered_at: DateTime.current
+
+        summary = notification.summary
+
+        expect(summary).to eq "Email was delivered on #{notification.delivered_at.to_date}."
+      end
+    end
+    context "for an email notification with a state of failed" do
+      it "indicates an email notification failed to deliver" do
+        notification = build_stubbed :email_notification, state: "failed", failed_at: DateTime.current
+
+        summary = notification.summary
+
+        expect(summary).to eq "Email cannot be delivered to the specified email address."
+      end
+    end
+    context "for a letter notification with a state of created" do
+      it "indicates a letter notification was created on a date" do
+        notification = build_stubbed :letter_notification, state: "created"
+
+        summary = notification.summary
+
+        expect(summary).to eq "Letter created on #{notification.created_at.to_date}."
+      end
+    end
+    context "for a letter notification with a state of sent" do
+      it "indicates a letter notification was sent" do
+        notification = build_stubbed :letter_notification, state: "sent", sent_at: DateTime.current
+
+        summary = notification.summary
+
+        expect(summary).to eq "Letter was sent on #{notification.sent_at.to_date}."
+      end
+    end
+    context "for an letter notification with a state of delivered" do
+      it "indicates an letter notification was delivered" do
+        notification = build_stubbed :letter_notification, state: "delivered", delivered_at: DateTime.current
+
+        summary = notification.summary
+
+        expect(summary).to eq "Letter was delivered on #{notification.delivered_at.to_date}."
+      end
+    end
+  end
+end
+
+RSpec.describe Notification, "#deliverable_by_email?" do
+  it "returns true if the notification mean is set to email" do
+    notification = build :email_notification
+
+    email_deliverable = notification.deliverable_by_email?
+
+    expect(email_deliverable).to eq true
+  end
+
+  it "returns false if the notification mean is not set to email" do
+    notification = build :letter_notification
+
+    email_deliverable = notification.deliverable_by_email?
+
+    expect(email_deliverable).to eq false
+  end
+end
+
+RSpec.describe Notification, "#address_to" do
+  context "for an email notification" do
+    it "returns the associated building's proprietor email" do
+      building = build :building, proprietor_email: "owner@example.com"
+      notification = build :email_notification, building: building
+
+      addressee = notification.addressed_to
+
+      expect(addressee).to eq "owner@example.com"
+    end
+  end
+end

--- a/spec/requests/callbacks/notification_status_spec.rb
+++ b/spec/requests/callbacks/notification_status_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "Callbacks - Notification Status" do
+  context "for a request without authentication" do
+    it "returns a 401 response" do
+      post(
+        callbacks_notification_statuses_path(format: :json),
+        params: { some_random_param: true }.to_json,
+        headers: { "CONTENT_TYPE" => "application/json" }
+      )
+
+      expect(response.status).to eq 401
+    end
+  end
+  context "if the notification was successfully delivered" do
+    it "updates to notification to delivered" do
+      notification = create :email_notification, building: create(:building)
+
+      post(
+        callbacks_notification_statuses_path(format: :json),
+        params: notification_body_for(notification, "delivered"),
+        headers: notification_headers
+      )
+
+      notification.reload
+      expect(response.status).to eq 201
+      expect(notification.state).to eq "delivered"
+      expect(notification.delivered_at.to_date).to eq Date.today
+    end
+  end
+  context "if the notification could not be delivered due to a temporary failure" do
+    it "enqueues the notification for retrying the send" do
+      notification = create :email_notification, building: create(:building)
+
+      expect(DeliverNotificationJob).to receive(:perform_later).with notification
+
+      post(
+        callbacks_notification_statuses_path(format: :json),
+        params: notification_body_for(notification, "temporary-failure"),
+        headers: notification_headers
+      )
+
+      notification.reload
+      expect(response.status).to eq 201
+      expect(notification.state).to eq "enqueued"
+    end
+  end
+  context "if the notification could not be delivered due to a permanent failure" do
+    it "sets the notification to failed" do
+      notification = create :email_notification, building: create(:building)
+
+      post(
+        callbacks_notification_statuses_path(format: :json),
+        params: notification_body_for(notification, "permanent-failure"),
+        headers: notification_headers
+      )
+
+      notification.reload
+      expect(response.status).to eq 201
+      expect(notification.state).to eq "failed"
+      expect(notification.failed_at.to_date).to eq Date.today
+    end
+  end
+end
+
+def notification_body_for(notification, status)
+  {
+    id: "",
+    reference: notification.id.to_s,
+    to: "",
+    status: status,
+    created_at: "",
+    completed_at: DateTime.current,
+    sent_at: "",
+    notification_type: "",
+  }.to_json
+end
+
+def notification_headers
+  {
+    "CONTENT_TYPE" => "application/json",
+    "Authorization" => "Bearer #{ENV.fetch("NOTIFY_CALLBACK_TOKEN")}"
+  }
+end

--- a/spec/support/notification_helpers.rb
+++ b/spec/support/notification_helpers.rb
@@ -1,0 +1,15 @@
+module NotificationHelpers
+  def stub_notify_response
+    stub_request(
+      :post,
+      "https://api.notifications.service.gov.uk/v2/notifications/email"
+    ).to_return(status: 200, body: response_body)
+  end
+
+  def response_body
+    {
+      id: SecureRandom.uuid,
+      uri: "http://someplace.fun/1"
+    }.to_json
+  end
+end

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -1,0 +1,9 @@
+module SignInHelpers
+  def sign_in_as_admin
+    user = create :user
+    visit "/admin"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_on "Sign in"
+  end
+end

--- a/spec/system/admin/admin_sends_survey_link_spec.rb
+++ b/spec/system/admin/admin_sends_survey_link_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Admin sends survey link" do
+  include NotificationHelpers
+  include SignInHelpers
+
+  before { stub_notify_response }
+
+  it "sending an email survey link" do
+    create :building, proprietor_email: "proprietor@example.com"
+
+    sign_in_as_admin
+    click_on "Email survey link"
+
+    expect(page).to have_content "Email was sent on #{Date.today}."
+  end
+end


### PR DESCRIPTION
This adds a structure for sending notifications to potential survey
users. It implements sending email notifications, and most of the
structure required to send letters as well.

In order to send notifications, this PR introduces the GovUK Notify API
ruby client. The implementation of notifications is based on the
documentation available here: https://docs.notifications.service.gov.uk/ruby.html#ruby-client-documentation

We also introduce DelayedJob as the backend to ActiveJob in order to
background the network requests to Notify.

I order to obtain updated statuses on the notifications, this PR also
introduces a structure to receive callback calls from the Notify API.


https://trello.com/c/LM8ZeJ97