### PR TITLE
Add status comments to summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ rspec_failures.txt
 
 #ignore mac ds files
 .DS_Store
+
+#ignore .env files
+.env

--- a/app/models/building_status.rb
+++ b/app/models/building_status.rb
@@ -13,6 +13,10 @@ class BuildingStatus < ApplicationRecord
     status.humanize
   end
 
+  def comments
+    status_details ? status_details.humanize : ""
+  end
+
   def should_terminate_survey?
     !existing?
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -2,7 +2,7 @@ class Section < ApplicationRecord
   belongs_to :content, polymorphic: true
   belongs_to :survey
 
-  delegate :name, :reply, :should_terminate_survey?, to: :content
+  delegate :name, :reply, :comments, :should_terminate_survey?, to: :content
 
   def to_partial_path
     content.to_partial_path

--- a/app/views/surveys/building_statuses/_building_status.html.erb
+++ b/app/views/surveys/building_statuses/_building_status.html.erb
@@ -7,3 +7,14 @@
   <% end %>
   </dd>
 </div>
+<% if !building_status.comments.empty? %>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">Building status comments</dt>
+  <dd class="govuk-summary-list__value"><%= building_status.comments %></dd>
+  <dd class="govuk-summary-list__actions">
+  <%= link_to [:edit, building_status.survey, building_status.content], class: "govuk-link" do %>
+    Change<span class="govuk-visually-hidden"> <%= building_status.name %></span>
+  <% end %>
+  </dd>
+</div>
+<% end %>

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -66,6 +66,9 @@ RSpec.describe "Building manager views survey reply summary" do
        click_on "Continue"
 
        expect(page).to have_text("Check your answers")
+       expect(page).to have_text("Demolished")
+       expect(page).to have_text("Building status comments")
+       expect(page).to have_text("I really want some apple pie")
      end
 
     it "allows managers to modify building tenure" do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9452321/94134724-4c5e9480-fe5a-11ea-9467-15a774c71549.png)

story:
https://trello.com/c/KOzpP45Z/151-chore-add-building-status-comments-to-summary-page-under-a-heading-of-building-status-comments