### PR TITLE
Fix summary for empty balconies and solar shading

### DIFF
--- a/app/controllers/surveys/insulations_controller.rb
+++ b/app/controllers/surveys/insulations_controller.rb
@@ -67,7 +67,16 @@ module Surveys
       end
 
       def next_section_incomplete?
-        BuildingExternalWallStructure.find_by(survey_id: survey.id).blank?
+        external_structure = BuildingExternalWallStructure.find_by(survey_id: survey.id)
+        if external_structure.blank?
+          return true
+        elsif external_structure.has_no_external_structures?
+          return false
+        elsif external_structure.solar_shading_material_detail_list.blank? || external_structure.balcony_material_detail_list.blank?
+          return true
+        end
+
+        false
       end
 
       def redirect_to_next_section

--- a/app/controllers/surveys/percentages_controller.rb
+++ b/app/controllers/surveys/percentages_controller.rb
@@ -33,10 +33,12 @@ module Surveys
       end
 
       if !percentages.blank?
-        if insulation_section_complete?
-          redirect_to survey_summary_path(survey)
-        else
+        if !insulation_section_complete?
           redirect_to new_survey_building_wall_insulation_path(survey: survey, building_wall: building_wall)
+        elsif insulation_section_complete? && balconies_and_insulations_incomplete?
+          redirect_to new_survey_building_external_wall_structure_path(survey)
+        else
+          redirect_to survey_summary_path(survey)
         end
       end
     end
@@ -67,6 +69,19 @@ module Surveys
 
       def insulation_section_complete?
         all_materials_needing_insulation.blank?
+      end
+
+      def balconies_and_insulations_incomplete?
+        external_structure = BuildingExternalWallStructure.find_by(survey_id: survey.id)
+        if external_structure.blank?
+          return true
+        elsif external_structure.has_no_external_structures?
+          return false
+        elsif external_structure.solar_shading_material_detail_list.blank? || external_structure.balcony_material_detail_list.blank?
+          return true
+        end
+
+        false
       end
   end
 end

--- a/app/models/material_detail_list.rb
+++ b/app/models/material_detail_list.rb
@@ -40,7 +40,7 @@ class MaterialDetailList < ApplicationRecord
 
     def has_one_primary_material_for_balcony
       material_count = [
-        has_timber_or_wood_primary_material,
+        has_timber_or_wood_primary_material?,
         has_glass_primary_material?,
         has_metal_primary_material?,
         has_concrete_primary_material?,

--- a/app/views/surveys/building_external_wall_structures/_building_external_wall_structure.html.erb
+++ b/app/views/surveys/building_external_wall_structures/_building_external_wall_structure.html.erb
@@ -1,47 +1,49 @@
-<div class="govuk-summary-list__row" data-information-displayed="<%= building_external_wall_structure.name.parameterize %>">
-  <dt class="govuk-summary-list__key"><%= building_external_wall_structure.name %></dt>
-  <dd class="govuk-summary-list__value"><%= building_external_wall_structure.reply %></dd>
-  <dd class="govuk-summary-list__actions">
-  <%= link_to [:edit, building_external_wall_structure.survey, building_external_wall_structure.content], class: "govuk-link" do %>
-    Change<span class="govuk-visually-hidden"> <%= building_external_wall_structure.name %></span>
+<% if !building_external_wall_structure.content.reply.blank? %>
+    <div class="govuk-summary-list__row" data-information-displayed="<%= building_external_wall_structure.name.parameterize %>">
+      <dt class="govuk-summary-list__key"><%= building_external_wall_structure.name %></dt>
+      <dd class="govuk-summary-list__value"><%= building_external_wall_structure.reply %></dd>
+      <dd class="govuk-summary-list__actions">
+      <%= link_to [:edit, building_external_wall_structure.survey, building_external_wall_structure.content], class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> <%= building_external_wall_structure.name %></span>
+      <% end %>
+      </dd>
+    </div>
+    <% if building_external_wall_structure.content.has_balconies? && !building_external_wall_structure.content.balcony_material_detail_list.blank? %>
+      <div class="govuk-summary-list__row" data-information-displayed="external-structure-balcony">
+        <dt class="govuk-summary-list__key">Balcony structure</dt>
+        <dd class="govuk-summary-list__value">
+          <% building_external_wall_structure.content.balcony_material_detail_list.reply.each do |material_placement, material_types| %>
+            <div>
+              <%= material_placement %>: <br /><%= material_types %>
+            </div>
+            <% end %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to edit_survey_building_external_wall_structure_material_detail_list_path(building_external_wall_structure.survey, building_external_wall_structure.content, building_external_wall_structure.content.balcony_material_detail_list), class: "govuk-link" do %>
+            Change<span class="govuk-visually-hidden"> Balcony structure materials</span>
+          <% end %>
+        </dd>
+      </div>
+    <% end %>
+  <% if building_external_wall_structure.content.has_solar_shading? && !building_external_wall_structure.content.solar_shading_material_detail_list.blank? %>
+    <div class="govuk-summary-list__row" data-information-displayed="external-structure-solar-shading">
+      <dt class="govuk-summary-list__key">Solar shading structure</dt>
+      <dd class="govuk-summary-list__value">
+        <%= building_external_wall_structure.content.solar_shading_material_detail_list.reply %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <%= link_to edit_survey_building_external_wall_structure_material_detail_list_path(building_external_wall_structure.survey, building_external_wall_structure.content, building_external_wall_structure.content.solar_shading_material_detail_list), class: "govuk-link" do %>
+          Change<span class="govuk-visually-hidden"> Solar shading structure materials</span>
+        <% end %>
+      </dd>
+    </div>
   <% end %>
-  </dd>
-</div>
-<% if building_external_wall_structure.content.has_balconies? %>
-  <div class="govuk-summary-list__row" data-information-displayed="external-structure-balcony">
-    <dt class="govuk-summary-list__key">Balcony structure</dt>
-    <dd class="govuk-summary-list__value">
-      <% building_external_wall_structure.content.balcony_material_detail_list.reply.each do |material_placement, material_types| %>
-        <div>
-          <%= material_placement %>: <br /><%= material_types %>
-        </div>
-      <% end %>
-    </dd>
-    <dd class="govuk-summary-list__actions">
-      <%= link_to edit_survey_building_external_wall_structure_material_detail_list_path(building_external_wall_structure.survey, building_external_wall_structure.content, building_external_wall_structure.content.balcony_material_detail_list), class: "govuk-link" do %>
-        Change<span class="govuk-visually-hidden"> Balcony structure materials</span>
-      <% end %>
-    </dd>
-  </div>
-<% end %>
-<% if building_external_wall_structure.content.has_solar_shading? %>
-  <div class="govuk-summary-list__row" data-information-displayed="external-structure-solar-shading">
-    <dt class="govuk-summary-list__key">Solar shading structure</dt>
-    <dd class="govuk-summary-list__value">
-      <%= building_external_wall_structure.content.solar_shading_material_detail_list.reply %>
-    </dd>
-    <dd class="govuk-summary-list__actions">
-      <%= link_to edit_survey_building_external_wall_structure_material_detail_list_path(building_external_wall_structure.survey, building_external_wall_structure.content, building_external_wall_structure.content.solar_shading_material_detail_list), class: "govuk-link" do %>
-        Change<span class="govuk-visually-hidden"> Solar shading structure materials</span>
-      <% end %>
-    </dd>
-  </div>
-<% end %>
-<% if building_external_wall_structure.content.has_other_structure? %>
-  <div class="govuk-summary-list__row" data-information-displayed="building-external-wall-structure-other-structures">
-    <dt class="govuk-summary-list__key">Other external structures</dt>
-    <dd class="govuk-summary-list__value"><%= building_external_wall_structure.content.other_structure_details %></dd>
-    <dd class="govuk-summary-list__actions">
-    </dd>
-  </div>
+  <% if building_external_wall_structure.content.has_other_structure? && !building_external_wall_structure.content.other_structure_details.blank? %>
+    <div class="govuk-summary-list__row" data-information-displayed="building-external-wall-structure-other-structures">
+      <dt class="govuk-summary-list__key">Other external structures</dt>
+      <dd class="govuk-summary-list__value"><%= building_external_wall_structure.content.other_structure_details %></dd>
+      <dd class="govuk-summary-list__actions">
+      </dd>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
- Issue:
When clicking Continue on "Are there any sizeable wall structures" then clicking back, and editing materials/percentages/insulations

The percentage and insulation controller currently see a "wall structure" has been created and redirect to summary. Ignoring the fact that despite a wall structure being created, there are no details for balconies or solar shading.

This PR does 3 things:
1. Ensure percentages redirects to external wall structure if details are not yet added
2. Ensure insulations redirects to external wall structure if details are not yet added
3. Ensures summary page doesn't blow up if details are not present

![image](https://user-images.githubusercontent.com/9452321/94174468-38805600-fe8d-11ea-9640-aedaeacf09b3.png)
