### PR TITLE
Configure capybara to use headless chrome by default

### DIFF
--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,0 +1,18 @@
+Capybara.register_driver :chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[window-size=1280,960], w3c: false }
+  )
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+Capybara.register_driver :chrome_headless do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless window-size=1280,960], w3c: false }
+  )
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
+end
+
+Capybara.javascript_driver = ENV.fetch("JS_DRIVER", "chrome_headless").to_sym
+Capybara.automatic_label_click = true


### PR DESCRIPTION
Allows overriding to use another driver by setting the JS_DRIVER environment variable. Also enables `automatic_label_click` as this is required for GOV.UK radio buttons/check boxes to work.