### PR TITLE
form: let sections say if they're relevant or not

### DIFF
--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -1,7 +1,7 @@
 module SummaryHelper
   def stages_with_forms(survey)
     stages = survey
-             .record.stages
+             .record.logical_stages
              .reject { |s| ["check_your_answers", "complete"].include? s }
 
     forms = stages

--- a/app/models/survey/record.rb
+++ b/app/models/survey/record.rb
@@ -13,7 +13,7 @@ module Survey
     store_accessor :data, :full_name, :email, :organisation
 
     # stage: has residential
-    store_accessor :data, :has_residential_use # FIXME: this should be indicated by the next stage
+    store_accessor :data, :has_residential_use
 
     # stage: residential use
     store_accessor :data, :usage

--- a/app/models/survey/sections/add_material_form.rb
+++ b/app/models/survey/sections/add_material_form.rb
@@ -31,6 +31,10 @@ module Survey
       def other_material?
         material == "other"
       end
+
+      def relevant?
+        record.has_residential_use != false
+      end
     end
   end
 end

--- a/app/models/survey/sections/balcony_materials_form.rb
+++ b/app/models/survey/sections/balcony_materials_form.rb
@@ -54,16 +54,6 @@ module Survey
         self.completed = !solar_shading_structures?
       end
 
-      def next_stage
-        if completed
-          "check_your_answers"
-        elsif solar_shading_structures?
-          "solar_shading_materials"
-        else
-          stage # something is wrong if we get here
-        end
-      end
-
       def other_main_material?
         balcony_main_material == "other"
       end
@@ -101,6 +91,10 @@ module Survey
         else
           params
         end
+      end
+
+      def relevant?
+        record.has_residential_use != false && record.structures&.include?("balconies")
       end
     end
   end

--- a/app/models/survey/sections/base_form.rb
+++ b/app/models/survey/sections/base_form.rb
@@ -9,7 +9,7 @@ module Survey
       include Survey::Naming
 
       delegate :completed, :completed=, to: :record
-      delegate :stage, :goto, to: :record
+      delegate :stage, :goto, :next_stage, to: :record
 
       after_save do
         if next_stage && next_stage != stage
@@ -17,8 +17,8 @@ module Survey
         end
       end
 
-      def next_stage
-        stage
+      def relevant?
+        true
       end
     end
   end

--- a/app/models/survey/sections/building_management_form.rb
+++ b/app/models/survey/sections/building_management_form.rb
@@ -20,8 +20,8 @@ module Survey
         is_right_to_manage == "yes"
       end
 
-      def next_stage
-        completed ? "check_your_answers" : "height"
+      def relevant?
+        record.has_residential_use != false
       end
     end
   end

--- a/app/models/survey/sections/check_your_answers_form.rb
+++ b/app/models/survey/sections/check_your_answers_form.rb
@@ -4,10 +4,6 @@ module Survey
       before_save do
         record.completed_at = Time.current
       end
-
-      def next_stage
-        "complete"
-      end
     end
   end
 end

--- a/app/models/survey/sections/external_wall_structures_form.rb
+++ b/app/models/survey/sections/external_wall_structures_form.rb
@@ -25,18 +25,6 @@ module Survey
         self.completed = !(balcony_structures? || solar_shading_structures?)
       end
 
-      def next_stage
-        if completed
-          "check_your_answers"
-        elsif balcony_structures?
-          "balcony_materials"
-        elsif solar_shading_structures?
-          "solar_shading_materials"
-        else
-          stage # something is wrong if we get here
-        end
-      end
-
       def structure_options
         EXTERNAL_WALLS_STRUCTURES
       end
@@ -63,6 +51,10 @@ module Survey
         else
           params
         end
+      end
+
+      def relevant?
+        record.has_residential_use != false
       end
     end
   end

--- a/app/models/survey/sections/external_walls_summary_form.rb
+++ b/app/models/survey/sections/external_walls_summary_form.rb
@@ -5,8 +5,8 @@ module Survey
         []
       end
 
-      def next_stage
-        completed ? "check_your_answers_form" : "external_wall_structures"
+      def relevant?
+        record.has_residential_use != false
       end
     end
   end

--- a/app/models/survey/sections/has_residential_form.rb
+++ b/app/models/survey/sections/has_residential_form.rb
@@ -7,10 +7,6 @@ module Survey
       before_save do
         self.completed = !has_residential_use
       end
-
-      def next_stage
-        completed ? "check_your_answers" : "residential_use"
-      end
     end
   end
 end

--- a/app/models/survey/sections/height_form.rb
+++ b/app/models/survey/sections/height_form.rb
@@ -7,8 +7,8 @@ module Survey
       attribute :number_of_storeys, :integer
       validates :number_of_storeys, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
 
-      def next_stage
-        completed ? "check_your_answers" : "external_walls_summary"
+      def relevant?
+        record.has_residential_use != false
       end
     end
   end

--- a/app/models/survey/sections/material_details_form.rb
+++ b/app/models/survey/sections/material_details_form.rb
@@ -24,6 +24,10 @@ module Survey
       def insulation_options
         INSULATION_MATERIALS
       end
+
+      def relevant?
+        record.has_residential_use != false
+      end
     end
   end
 end

--- a/app/models/survey/sections/ownership_form.rb
+++ b/app/models/survey/sections/ownership_form.rb
@@ -22,10 +22,6 @@ module Survey
       def other_role?
         role == "other"
       end
-
-      def next_stage
-        completed ? "check_your_answers" : "has_residential"
-      end
     end
   end
 end

--- a/app/models/survey/sections/residential_use_form.rb
+++ b/app/models/survey/sections/residential_use_form.rb
@@ -10,8 +10,8 @@ module Survey
         USES
       end
 
-      def next_stage
-        completed ? "check_your_answers" : "building_management"
+      def relevant?
+        record.has_residential_use != false
       end
     end
   end

--- a/app/models/survey/sections/solar_shading_materials_form.rb
+++ b/app/models/survey/sections/solar_shading_materials_form.rb
@@ -28,10 +28,6 @@ module Survey
         self.completed = true
       end
 
-      def next_stage
-        "check_your_answers"
-      end
-
       def other_solar_shading_materials?
         solar_shading_materials.include?("other")
       end
@@ -53,6 +49,10 @@ module Survey
         else
           params
         end
+      end
+
+      def relevant?
+        record.has_residential_use != false && record.structures&.include?("solar_shading")
       end
     end
   end

--- a/app/models/survey/sections/uprn_form.rb
+++ b/app/models/survey/sections/uprn_form.rb
@@ -16,8 +16,8 @@ module Survey
         end
       end
 
-      def next_stage
-        completed ? "check_your_answers" : "ownership"
+      def relevant?
+        true
       end
 
       def uprn_valid?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_PASSWORD: postgres
   web:
     build: .
+    stdin_open: true
     environment:
       DATABASE_URL: postgres://postgres:postgres@db:5432
     ports:

--- a/features/alex_fills_in_a_survey.feature
+++ b/features/alex_fills_in_a_survey.feature
@@ -18,3 +18,13 @@ Feature: Alex fills in a report about a building
     Then the page contains "Building height"
     When I press "Back"
     Then the page contains "Building management details"
+
+  Scenario: Alex only sees relevant sections when reviewing answers
+    Given I start filling a survey for a building
+    And I fill in the user details
+    And I press "Continue"
+    And the page contains "Is any part of the building used for residential purposes?"
+    And I choose "No"
+    And I press "Continue"
+    Then the page contains "Check your answers"
+    And the page doesn't contain "Building management"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -2,6 +2,10 @@ Then('the page contains {string}') do |content|
   expect(page).to have_content(content)
 end
 
+Then('the page doesn\'t contain {string}') do |content|
+  expect(page).to_not have_content(content)
+end
+
 Then('the next page is {string}') do |header|
   expect(page.find('h1')).to have_content(header)
 end


### PR DESCRIPTION
This allows us to form a sequence of `logical_stages` for the survey,
which is leveraged by the "check your answers" stage to only show the
relevant sections of the form.