### PR TITLE
Refactor the delete material form

### DIFF
--- a/app/models/survey/sections/delete_material_form.rb
+++ b/app/models/survey/sections/delete_material_form.rb
@@ -8,19 +8,14 @@ module Survey
       attribute :material, :model, model: Material
       attribute :materials, :collection, collection: MaterialList, item: Material
 
-      attribute :confirm_deletion, :enum, values: %w[yes no]
-      validates :confirm_deletion, inclusion: { in: %w[yes no] }
+      attribute :confirm_deletion, :boolean, default: false
 
       before_transition do
         record.material = nil
       end
 
-      before_save if: :delete_material? do
+      before_save if: :confirm_deletion do
         materials.delete(material.id)
-      end
-
-      def delete_material?
-        confirm_deletion == "yes"
       end
 
       def next_stage

--- a/app/views/surveys/_delete_material_form.html.erb
+++ b/app/views/surveys/_delete_material_form.html.erb
@@ -1,42 +1,21 @@
 <%= render "application/back_link", chosen_path: goto_path("external_walls_summary") %>
 
-<%= form_with model: @survey do |form| %>
-  <%= form.hidden_field :confirm_deletion %>
+<div class="govuk-grid-row govuk-!-margin-top-2">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Are you sure you want to delete the material ‘<%= t(@survey.material.type, scope: :"survey.wall_material.types", other: @survey.material.other_type) %>’?
+    </h1>
 
-  <div class="govuk-grid-row govuk-!-margin-top-2">
-    <div class="govuk-grid-column-two-thirds">
-      <%= error_summary @survey %>
+    <p class="govuk-body-l">
+      This cannot be undone.
+    </p>
 
-      <%= form_group for: [@survey, :confirm_deletion] do %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
-              Are you sure you want to delete the material ‘<%= t(@survey.material.type, scope: :"survey.wall_material.types", other: @survey.material.other_type) %>’?
-            </h1>
-          </legend>
-
-            <div class="govuk-hint">
-              This cannot be undone.
-            </div>
-
-            <%= error_message_for @survey, :confirm_deletion %>
-
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <%= form.radio_button :confirm_deletion, "yes", class: "govuk-radios__input" %>
-                <%= form.label :confirm_deletion, value: "yes", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios__item">
-                <%= form.radio_button :confirm_deletion, "no", class: "govuk-radios__input" %>
-                <%= form.label :confirm_deletion, value: "no", class: "govuk-label govuk-radios__label" %>
-              </div>
-            </div>
-        </fieldset>
-      <% end %>
-
-      <div class="govuk-form-group">
-        <%= form.submit "Delete ‘#{t(@survey.material.type, scope: :"survey.wall_material.types", other: @survey.material.other_type)}’", class: "govuk-button govuk-button--warning" %>
+    <%= form_tag survey_path do %>
+      <%= hidden_field_tag "survey[confirm_deletion]", "true" %>
+      <div class="govuk-button-group">
+        <%= button_tag "Delete ‘#{t(@survey.material.type, scope: :"survey.wall_material.types", other: @survey.material.other_type)}’", name: nil, class: "govuk-button govuk-button--warning",data: { module: "govuk-button" } %>
+        <%= link_to "Go back to summary", goto_path("external_walls_summary"), draggable: false, class: "govuk-button govuk-button--secondary" %>
       </div>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/features/sections/alex_fills_in_the_material_section.feature
+++ b/features/sections/alex_fills_in_the_material_section.feature
@@ -91,7 +91,7 @@ Feature: Alex fills in the material section
 
   Scenario: Alex edits a material
     Given a material "Brick" that covers "40–60%" of the building and is insulated with "Phenolic foam insulation"
-    Given a material "Glass" that covers "20–40%" of the building and is insulated with "Mineral wool"
+    And a material "Glass" that covers "20–40%" of the building and is insulated with "Mineral wool"
     When I press "Edit" for the material "Glass"
     Then the page contains "Update an external wall material"
     When I press "Continue"
@@ -110,7 +110,7 @@ Feature: Alex fills in the material section
 
   Scenario: Alex deletes a material
     Given a material "Brick" that covers "40–60%" of the building and is insulated with "Phenolic foam insulation"
-    Given a material "Glass" that covers "20–40%" of the building and is insulated with "Mineral wool"
+    And a material "Glass" that covers "20–40%" of the building and is insulated with "Mineral wool"
     Then the page contains "External features of the building"
     And I should see the following within "External wall materials"
       | Material | Insulation               | Percentage |
@@ -121,8 +121,7 @@ Feature: Alex fills in the material section
       | Total percentage |    60–100% |
     When I press "Delete" for the material "Glass"
     Then the page contains "Are you sure you want to delete the material ‘Glass’?"
-    When I choose "Delete this material"
-    And I press "Delete ‘Glass’"
+    When I press "Delete ‘Glass’"
     Then the page contains "External features of the building"
     And I should see the following within "External wall materials"
       | Material | Insulation               | Percentage |
@@ -133,6 +132,29 @@ Feature: Alex fills in the material section
     And I should see the following within "External wall materials"
       | Material         | Percentage |
       | Total percentage |     40–60% |
+
+  Scenario: Alex thinks about deleting a material
+    Given a material "Brick" that covers "40–60%" of the building and is insulated with "Phenolic foam insulation"
+    And a material "Glass" that covers "20–40%" of the building and is insulated with "Mineral wool"
+    Then the page contains "External features of the building"
+    And I should see the following within "External wall materials"
+      | Material | Insulation               | Percentage |
+      | Brick    | Phenolic foam insulation |     40–60% |
+      | Glass    | Mineral wool             |     20–40% |
+    And I should see the following within "External wall materials"
+      | Material         | Percentage |
+      | Total percentage |    60–100% |
+    When I press "Delete" for the material "Glass"
+    Then the page contains "Are you sure you want to delete the material ‘Glass’?"
+    When I press "Go back to summary"
+    Then the page contains "External features of the building"
+    And I should see the following within "External wall materials"
+      | Material | Insulation               | Percentage |
+      | Brick    | Phenolic foam insulation |     40–60% |
+      | Glass    | Mineral wool             |     20–40% |
+    And I should see the following within "External wall materials"
+      | Material         | Percentage |
+      | Total percentage |    60–100% |
 
   Scenario: Alex tries to go to the next section with no materials
     Then the page contains "External features of the building"


### PR DESCRIPTION
It didn't make sense to present two radio buttons and then have the user click 'Delete' to cancel so just offer two buttons.

![image](https://user-images.githubusercontent.com/6321/114890982-65815f80-9e03-11eb-9131-190a947a8b4a.png)
