### PR TITLE
admin: cleanup dashboard interface

### DIFF
--- a/app/views/admin/_filters.html.erb
+++ b/app/views/admin/_filters.html.erb
@@ -4,7 +4,7 @@
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m">Filters</h2>
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-third">
+          <div class="govuk-grid-column-one-quarter">
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -23,7 +23,7 @@
               </fieldset>
             </div>
           </div>
-          <div class="govuk-grid-column-one-third">
+          <div class="govuk-grid-column-one-quarter">
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,17 +1,11 @@
 <div class="dashboard">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
-      <h1 class="govuk-heading-l">Dashboard</h1>
-    </div>
-
-    <div class="govuk-grid-column-one-half dashboard-actions">
-      <%= link_to "Upload building list", new_admin_bulk_import_path, class: "govuk-button" %>
-      <%= link_to "Add a building record", new_admin_building_path, class: "govuk-button" %>
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">All buildings</h1>
     </div>
   </div>
 
   <%= render "admin/buildings/flash_content" %>
-
   <%= render "admin/filters" %>
 
   <div class="govuk-grid-row">
@@ -33,9 +27,8 @@
                 <% end %>
               </span>
             </h2>
-            <%= submit_tag "Send email", class: "govuk-button" %>
-            <%= submit_tag "Send letter", class: "govuk-button" %>
-            <%= submit_tag "Mark as 'on Delta'", class: "govuk-button", data: { disable_with: "Processing update" } %>
+            <%= submit_tag "Send letter", class: "govuk-button govuk-button--secondary" %>
+            <%= submit_tag "Mark as 'on Delta'", class: "govuk-button govuk-button--secondary", data: { disable_with: "Processing update" } %>
           </caption>
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/spec/system/admin/admin_manages_building_records_spec.rb
+++ b/spec/system/admin/admin_manages_building_records_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "Admin manages building records" do
     fill_in "Email", with: user.email
     fill_in "Password", with: user.password
     click_on "Sign in"
-    click_on "Upload building list"
+
+    visit new_admin_bulk_import_path
 
     attach_file "Upload a CSV file", building_list_fixture
 
@@ -21,37 +22,5 @@ RSpec.describe "Admin manages building records" do
 
     expect(page).to have_content parsed_building_list_fixture.first["uprn"]
     expect(page).to have_content parsed_building_list_fixture.first["pao"]
-  end
-
-  it "adding/editing a building record" do
-    user = create :user
-
-    visit "/admin"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_on "Sign in"
-    click_on "Add a building record"
-    fill_in "UPRN", with: "0987654321"
-    fill_in "Building name", with: "ACME Central"
-    fill_in "Building street", with: "1, Dynamite Lane"
-    fill_in "Building postcode", with: "SE23 3HH"
-    fill_in "Proprietor name", with: "Coyote Developments"
-    fill_in "Proprietor email", with: "beepbeep@example.com"
-    fill_in "Proprietor address", with: "Runner Building, 34, Boom Street, ACME 12, NeverLand"
-    click_on "Add building"
-
-    expect(page).to have_content "0987654321"
-    expect(page).to have_content "1, Dynamite Lane"
-
-    click_on "0987654321"
-
-    fill_in "UPRN", with: "1234567890"
-    fill_in "Building street", with: "1, Edited Street, ACME 13"
-    click_on "Update building record"
-
-    expect(page).not_to have_content "0987654321"
-    expect(page).to have_content "1234567890"
-    expect(page).not_to have_content "1, Dynamite Lane"
-    expect(page).to have_content "1, Edited Street, ACME 13"
   end
 end


### PR DESCRIPTION
* we don't want the "add building" set of features for now;
* we are postponing email-related features.

Remove associated controls and make some buttons secondary to avoid
the multiple calls-to-action on the page.

# Before
![image](https://user-images.githubusercontent.com/107635/115265902-96c59c80-a12f-11eb-9f28-274a620fdb39.png)

# After
![image](https://user-images.githubusercontent.com/107635/115265941-9fb66e00-a12f-11eb-8052-c1bf7cbb8c3d.png)



