### PR TITLE
notify: don't add the UPRN querystring in the link

### DIFF
--- a/app/models/notification_client.rb
+++ b/app/models/notification_client.rb
@@ -31,7 +31,7 @@ class NotificationClient
           address_line_1: notification.building.street || "",
           postal_code: notification.building.postcode || "",
           uprn: notification.building.uprn,
-          survey_link: root_url(uprn: notification.building.uprn, host: ENV.fetch("APPLICATION_HOST"))
+          survey_link: root_url(host: ENV.fetch("APPLICATION_HOST"))
         }
       }
     end
@@ -53,7 +53,7 @@ class NotificationClient
           building_address_line_1: notification.building.street || "",
           building_postal_code: notification.building.postcode || "",
           uprn: notification.building.uprn,
-          survey_link: root_url(uprn: notification.building.uprn, host: ENV.fetch("APPLICATION_HOST"))
+          survey_link: root_url(host: ENV.fetch("APPLICATION_HOST"))
         }
       }
     end

--- a/spec/models/notification_client_spec.rb
+++ b/spec/models/notification_client_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe NotificationClient, "#deliver" do
           address_line_1: "1 Infinite Loop",
           postal_code: "ACME B12",
           uprn: "01234567890",
-          survey_link: "http://#{ENV.fetch("APPLICATION_HOST")}/?uprn=01234567890"
+          survey_link: "http://#{ENV.fetch("APPLICATION_HOST")}/"
         }
       )
     end
@@ -62,7 +62,7 @@ RSpec.describe NotificationClient, "#deliver" do
           building_address_line_1: "1 Infinite Loop",
           building_postal_code: "ACME B12",
           uprn: "01234567890",
-          survey_link: "http://#{ENV.fetch("APPLICATION_HOST")}/?uprn=01234567890",
+          survey_link: "http://#{ENV.fetch("APPLICATION_HOST")}/",
           address_line_1: "Berkeley House",
           address_line_2: "304 Regents Park Road",
           address_line_3: "London",


### PR DESCRIPTION
As discussed with the team it's a lot easier to just send people to
the root URL of the website and have them land on the homepage and
click "Start" and enter the UPRN from the letter, rather than having
some awkward querystring embedded in the letter to help them skip a
step and a half (that might actually provide them with some context).