### PR TITLE
fix: redirect to the right previous page with the back button

### DIFF
--- a/app/controllers/admin/buildings_controller.rb
+++ b/app/controllers/admin/buildings_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class BuildingsController < AdminController
     before_action :build_building, only: %i[new create]
     before_action :find_building, except: :index
-    before_action :find_buildings, only: :index
+    before_action :find_buildings, :set_current_search, only: :index
 
     def index
       respond_to do |format|
@@ -123,6 +123,10 @@ module Admin
       headers["Cache-Control"] ||= "no-cache"
       headers["Last-Modified"] = time.httpdate
       headers.delete("Content-Length")
+    end
+
+    def set_current_search
+      session["current_search"] = @buildings.current_params
     end
   end
 end

--- a/app/views/admin/buildings/show.html.erb
+++ b/app/views/admin/buildings/show.html.erb
@@ -1,4 +1,4 @@
-<%= render "application/back_link", chosen_path: admin_root_path %>
+<%= render "application/back_link", chosen_path: admin_buildings_path(session["current_search"]), custom_label: "Back to search results" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/application/_back_link.html.erb
+++ b/app/views/application/_back_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Back', chosen_path, class: 'govuk-back-link' %>
+<%= link_to defined?(custom_label) ? custom_label : 'Back', chosen_path, class: 'govuk-back-link' %>


### PR DESCRIPTION
If an admin is browsing surveys and decide to load a particular one
then click "Back", the back button takes them back to the admin home
page without remembering the previous tab or any other parameters like
page number.

Use the built-in :back to have Rails automatically handle it.