### PR TITLE
admin: allow admins to edit multiple surveys

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -45,6 +45,8 @@ class SurveysController < ApplicationController
 
     session.clear unless session.exists?
 
+    Survey.clear_previous_surveys(session.id.to_s)
+
     record.reset!(session.id)
 
     redirect_to survey_path

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -13,6 +13,10 @@ module Survey
       build(find_or_initialize(session_id))
     end
 
+    def clear_previous_surveys(session_id)
+      Survey::Record.where(session_id: session_id).update(session_id: nil)
+    end
+
     private
 
     def build(record)

--- a/db/migrate/20210519164701_remove_null_constraint_on_session_id.rb
+++ b/db/migrate/20210519164701_remove_null_constraint_on_session_id.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintOnSessionId < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :survey_records, :session_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_172908) do
+ActiveRecord::Schema.define(version: 2021_05_19_164701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2021_05_18_172908) do
 
   create_table "survey_records", force: :cascade do |t|
     t.bigint "building_id"
-    t.string "session_id", null: false
+    t.string "session_id"
     t.string "stage", limit: 50, default: "uprn", null: false
     t.jsonb "data", default: {}, null: false
     t.datetime "completed_at"

--- a/features/admin/suzie_interacts_with_a_building.feature
+++ b/features/admin/suzie_interacts_with_a_building.feature
@@ -36,3 +36,14 @@ Feature: Suzie the admin interacts with a building
   Scenario: Suzie can see an edit link for rejected surveys
     Given I press "Reject survey data"
     Then the page contains "the link below to edit their survey"
+
+  Scenario: Suzie can edit multiple surveys
+    Given a survey has been "rejected" for UPRN 1111111111
+    And a survey has been "rejected" for UPRN 2222222222
+    When I visit the edit link for UPRN 1111111111
+    And I press "Submit survey"
+    And I visit the edit link for UPRN 2222222222
+    And I press "Submit survey"
+    Then the page contains "successfully submitted a survey"
+    And the building with UPRN 1111111111 has the "received" survey status
+    And the building with UPRN 2222222222 has the "received" survey status


### PR DESCRIPTION
Drop the not-null constraint on the survey records' session_id but
ensure it remains unique by nullifying any other surveys with that
session_id used in the recovery process.