### PR TITLE
Add further search capabilities on buildings

### DIFF
--- a/app/controllers/admin/buildings_controller.rb
+++ b/app/controllers/admin/buildings_controller.rb
@@ -71,10 +71,6 @@ module Admin
       redirect_to admin_building_path(@building), notice: "Survey state has been updated."
     end
 
-    def uprn_search
-      redirect_to action: 'show', uprn: params[:uprn]
-    end
-
     private
 
     def building_params
@@ -96,13 +92,6 @@ module Admin
 
     def find_building
       @building = Building.find_by(uprn: building_uprn)
-
-      # rubocop:disable Style/GuardClause
-      if @building.nil?
-        flash[:notification] = t(:no_building_found, scope: "errors", uprn: building_uprn)
-        redirect_to action: 'index' and return
-      end
-      # rubocop:enable Style/GuardClause
     end
 
     def build_building

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,0 +1,8 @@
+module Admin
+  class SearchesController < AdminController
+    def show
+      @search_term = params[:q]
+      @buildings = Building.search(params)
+    end
+  end
+end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -18,7 +18,7 @@ class Building < ApplicationRecord
 
   scope :ordered_by_uprn, -> { order uprn: :asc }
 
-  extend Searchable(:uprn, :building_name, :land_registry_proprietor_name)
+  extend Searchable(:uprn, :building_name, :street, :city_town, :postcode)
 
   include Browseable
   include DeltaCsvMapper

--- a/app/views/admin/buildings/index.html.erb
+++ b/app/views/admin/buildings/index.html.erb
@@ -5,18 +5,10 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="govuk-form-group">
-        <%= form_with(url: uprn_search_admin_buildings_path, method: :get) do |f| %>
-          <%= f.label :uprn, "UPRN", class: "govuk-label" %>
-          <%= f.text_field :uprn, { class: "govuk-input govuk-input--width-10", required: true, placeholder: '1234567890' } %>
-
-          <%= f.submit "Find by UPRN", class: "govuk-button" %>
-        <% end %>
-      </div>
-    </div>
-  </div>
+  <%= render(
+    partial: "admin/shared/search_bar",
+    locals: { search_term: nil }
+  ) %>
 
   <ul class="govuk-tabs__list" role="tablist">
     <% SurveyStateMachine.states.each do |state| %>

--- a/app/views/admin/buildings/show.html.erb
+++ b/app/views/admin/buildings/show.html.erb
@@ -1,4 +1,4 @@
-<%= render "application/back_link", chosen_path: admin_buildings_path(session["current_search"]), custom_label: "Back to search results" %>
+<%= render "application/back_link", chosen_path: request.referrer, custom_label: "Back to search results" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/admin/buildings/tables/_search_results.html.erb
+++ b/app/views/admin/buildings/tables/_search_results.html.erb
@@ -1,0 +1,25 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Search results</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">UPRN</th>
+      <th scope="col" class="govuk-table__header">Address</th>
+      <th scope="col" class="govuk-table__header">State</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% buildings.each do |building| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= link_to building.uprn, admin_building_path(building), class: "govuk-link" %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= building.address %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= building.survey_state.current_state.humanize %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/searches/show.html.erb
+++ b/app/views/admin/searches/show.html.erb
@@ -1,0 +1,32 @@
+<div class="admin">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h1 class="govuk-heading-l">Building search results (<%= @buildings.count %>)</h1>
+    </div>
+  </div>
+
+  <%= render(
+    partial: "admin/shared/search_bar",
+    locals: { search_term: @search_term }
+  ) %>
+
+  <% if @buildings.total_pages > 1 %>
+    <p class="govuk-body">Page <%= @buildings.current_page %>/<%= @buildings.total_pages %></p>
+
+    <div class="govuk-button-group">
+      <% if @buildings.first_page? %>
+        <span class="govuk-button govuk-button--secondary govuk-button--disabled">Previous page</span>
+      <% else %>
+        <%= link_to "Previous page", admin_search_path(@buildings.previous_params), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+
+      <% if @buildings.last_page? %>
+        <span class="govuk-button govuk-button--secondary govuk-button--disabled">Next page</span>
+      <% else %>
+        <%= link_to "Next page", admin_search_path(@buildings.next_params), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= render "admin/buildings/tables/search_results", buildings: @buildings %>
+</div>

--- a/app/views/admin/shared/_search_bar.html.erb
+++ b/app/views/admin/shared/_search_bar.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-form-group">
+      <%= form_with(url: admin_search_path, method: :get) do |f| %>
+        <%= f.label :q, "Search", class: "govuk-label" %>
+        <%= f.text_field(
+           :q,
+           {
+             class: "govuk-input govuk-!-width-three-quarters",
+             required: true,
+             value: search_term
+           }
+        ) %>
+        <%= f.submit "Search", class: "govuk-button" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: "buildings#index"
 
+    resource :search, only: [:show]
+
     scope "/buildings", as: "building" do
       resource :delta, only: [:update]
 

--- a/features/admin/suzie_interacts_with_a_building.feature
+++ b/features/admin/suzie_interacts_with_a_building.feature
@@ -47,7 +47,3 @@ Feature: Suzie the admin interacts with a building
     Then the page contains "successfully submitted a survey"
     And the building with UPRN 1111111111 has the "received" survey status
     And the building with UPRN 2222222222 has the "received" survey status
-
-  Scenario: Suzie tries to visit a non-existent building
-    Given I look at the details page for UPRN 123
-    Then the page contains "No building found with UPRN 123"

--- a/features/admin/suzie_interacts_with_the_buildings_list.feature
+++ b/features/admin/suzie_interacts_with_the_buildings_list.feature
@@ -57,8 +57,12 @@ Feature: Suzie the admin views and edits buildings on the admin
     When I press "Previous page"
     Then the page contains "Page 1/2"
 
-  Scenario: Suzie can find a building by UPRN
-    Given I am logged into the admin
-    And I fill in "UPRN" with "1234567890"
-    When I press "Find by UPRN"
+  Scenario: Suzie can navigate back to the right page
+    Given a survey has been "not_contacted" for UPRN 123
+    And I am logged into the admin
+    And I look at the list of buildings
+    When I go to the "Not contacted" tab
+    And I press "123"
     Then the page contains "Edit building details"
+    When I press "Back to search results"
+    Then the page contains "Not contacted"

--- a/features/admin/suzie_searches_for_buildings.feature
+++ b/features/admin/suzie_searches_for_buildings.feature
@@ -1,0 +1,30 @@
+Feature: Suzie the admin searches for buildings on the admin
+  Background:
+    Given a building exists with UPRN 1234567890
+    And a building exists with UPRN: 1234567891, name: "Southwark House", postcode: "SE1 2QH", street: "Tooley Street", city: "Manchester"
+    And I am logged into the admin
+
+  Scenario Outline: Suzie can search on multiple criteria
+    Given I fill in "Search" with "<term>"
+    When I press "Search"
+    Then there is a search result for UPRN 1234567891
+
+    Scenarios:
+      | criteria | term            |
+      | uprn     | 1234567891      |
+      | address  | Southwark House |
+      | postcode | SE1 2QH         |
+      | street   | Tooley Street   |
+      | city     | Manchester      |
+
+  Scenario: Suzie searches for a non-existent building
+    Given I fill in "Search" with "160 doesn't exist"
+    When I press "Search"
+    Then the page contains "Building search results (0)"
+
+  Scenario: Suzie can navigate back to the search results page
+    Given I fill in "Search" with "Tooley Street"
+    When I press "Search"
+    And I press "1234567891"
+    And I press "Back to search results"
+    Then the page contains "Building search results (1)"

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -110,3 +110,9 @@ When('I go to the {string} tab') do |tab|
     And I press "#{tab}"
   )
 end
+
+Then('there is a search result for UPRN {int}') do |uprn|
+  table = page.find(:table, "Search results")
+
+  expect(table).to have_selector(:table_row, "UPRN" => uprn.to_s)
+end

--- a/features/step_definitions/survey_steps.rb
+++ b/features/step_definitions/survey_steps.rb
@@ -10,6 +10,10 @@ Given('a building exists with UPRN {int}') do |uprn|
   @building = FactoryBot.create(:building, uprn: uprn)
 end
 
+Given('a building exists with UPRN: {int}, name: {string}, postcode: {string}, street: {string}, city: {string}') do |uprn, name, postcode, street, city|
+  @building = FactoryBot.create(:building, uprn: uprn, building_name: name, postcode: postcode, street: street, city_town: city)
+end
+
 Given('the building with UPRN {int} is on DELTA') do |uprn|
   Building.find_by(uprn: uprn).update!(on_delta: true)
 end


### PR DESCRIPTION
Admins can now search by
- UPRN
- Building name
- Building address (including postcode)

NB - the search parameters have to be formatted exactly, i.e. "SE1 2HL" will work, "SE12HL" won't.