### PR TITLE
Update back link text on building show page

### DIFF
--- a/app/views/admin/buildings/show.html.erb
+++ b/app/views/admin/buildings/show.html.erb
@@ -1,4 +1,4 @@
-<%= render "application/back_link", chosen_path: request.referrer, custom_label: "Back to search results" %>
+<%= render "application/back_link", chosen_path: request.referrer, custom_label: "Back" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/features/admin/suzie_interacts_with_the_buildings_list.feature
+++ b/features/admin/suzie_interacts_with_the_buildings_list.feature
@@ -64,5 +64,5 @@ Feature: Suzie the admin views and edits buildings on the admin
     When I go to the "Not contacted" tab
     And I press "123"
     Then the page contains "Edit building details"
-    When I press "Back to search results"
+    When I press "Back"
     Then the page contains "Not contacted"

--- a/features/admin/suzie_searches_for_buildings.feature
+++ b/features/admin/suzie_searches_for_buildings.feature
@@ -26,5 +26,5 @@ Feature: Suzie the admin searches for buildings on the admin
     Given I fill in "Search" with "Tooley Street"
     When I press "Search"
     And I press "1234567891"
-    And I press "Back to search results"
+    And I press "Back"
     Then the page contains "Building search results (1)"


### PR DESCRIPTION
### What

Change back link on building show page to read 'Back' instead of 'Back to search results'

### Why

The admin can navigate to this page from both the buildings index and the search results page.