### PR TITLE
Ensure users fill in either height in m or storeys

### DIFF
--- a/app/models/survey/sections/height_form.rb
+++ b/app/models/survey/sections/height_form.rb
@@ -7,6 +7,9 @@ module Survey
       attribute :number_of_storeys, :integer
       validates :number_of_storeys, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
 
+      validates :height_in_metres, presence: true, unless: ->(survey) { survey.number_of_storeys.present? }
+      validates :number_of_storeys, presence: true, unless: ->(survey) { survey.height_in_metres.present? }
+
       def next_stage
         completed ? "check_your_answers" : "external_walls_summary"
       end

--- a/app/views/surveys/_height_form.html.erb
+++ b/app/views/surveys/_height_form.html.erb
@@ -11,7 +11,16 @@
         </legend>
 
         <div class="govuk-hint">
-          If known please enter the building’s height in metres and storeys.
+          Tell us the building's height. You can tell us in two ways:
+          <ul>
+            <li>
+              height in metres
+            </li>
+            <li>
+              number of storeys
+            </li>
+          </ul>
+          If possible, tell us both.
         </div>
 
         <%= form_group for: [@survey, :height_in_metres] do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,8 +300,8 @@ en:
         building_owner: "Building owner (optional)"
         building_developer: "Building developer (optional)"
         managing_agent: "Managing agent (optional)"
-        height_in_metres: "Height in metres (optional)"
-        number_of_storeys: "Number of storeys (optional)"
+        height_in_metres: "Height in metres"
+        number_of_storeys: "Number of storeys"
         confirm_deletion:
           "yes": "Delete this material"
           "no": "Go back to the summary"
@@ -364,11 +364,13 @@ en:
             height_in_metres:
               greater_than: "The building height must be more than %{count} metres"
               not_a_number: "The building height must be a number"
+              blank: "You must fill in at least one box. If you don't know the building's height in metres, please tell us the number of storeys."
 
             number_of_storeys:
               greater_than: "The number of storeys must be more than %{count}"
               not_a_number: "The number of storeys must be a number"
               not_an_integer: "The number of storeys must be a whole number"
+              blank: "You must fill in at least one box. If you don't know the number of storeys, please tell us the building's height in metres."
 
             materials:
               blank: "Please add at least one material"

--- a/features/sections/alex_fills_in_the_height_section.feature
+++ b/features/sections/alex_fills_in_the_height_section.feature
@@ -1,0 +1,24 @@
+Feature: Alex fills in the height section
+  Background:
+    Given a building survey at stage "height"
+
+  Scenario: Alex completes the building height section
+    Given I fill in "Height in metres" with "18"
+    And I fill in "Number of storeys" with "10"
+    And I press "Continue"
+    Then the page contains "External features of the building"
+
+  Scenario: Alex does not fill in any heights
+    Given I press "Continue"
+    Then the page contains an error about "You must fill in at least one box. If you don't know the building's height in metres, please tell us the number of storeys."
+    Then the page contains an error about "You must fill in at least one box. If you don't know the number of storeys, please tell us the building's height in metres."
+
+  Scenario: Alex fills in only the height in metres
+    Given I fill in "Height in metres" with "18"
+    And I press "Continue"
+    Then the page contains "External features of the building"
+
+  Scenario: Alex fills in only the number of storeys
+    Given I fill in "Number of storeys" with "10"
+    And I press "Continue"
+    Then the page contains "External features of the building"


### PR DESCRIPTION
Users have to fill in at least one of the options, if not both