### PR TITLE
Correct deployment note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,4 @@ docker-compose up
 
 The project is hosted on Heroku.
 
-The `main` branch is automatically deployed to the staging environments.
-
-**production is deployed manually**.
+**staging and production are deployed manually**.


### PR DESCRIPTION
Automatic deploys don't seem to be enabled for staging which contradicts the readme note, so update the readme for now as I'm not sure if we want to enable this or not.

See https://dashboard.heroku.com/apps/southwark-bsp-staging/deploy/github