### PR TITLE
Update nokogiri to 1.13.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     multi_test (0.1.2)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)


### PR DESCRIPTION
Addresses CVE-2022-24836, CVE-2018-25032, CVE-2022-23437 and CVE-2022-24839.