### PR TITLE
Use fake credentials in test environment

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,5 @@
 APPLICATION_HOST=localhost
+
+# These are fake credentials just formatted correctly so the client accepts them
+NOTIFY_API_KEY=test-f0cf3daf-1e71-4401-9534-955267607d64-a34eb6f8-9fb9-4fb6-9931-ef69bd51cbc1
+NOTIFY_CALLBACK_TOKEN=8659aa65-61d4-4b58-9f54-0917b28b874a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,8 +124,6 @@ jobs:
       - name: Run rspec specs
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-          NOTIFY_CALLBACK_TOKEN: ${{ secrets.NOTIFY_CALLBACK_TOKEN }}
           RAILS_ENV: test
         run: |
           bundle exec rspec
@@ -179,7 +177,5 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RAILS_ENV: test
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-          NOTIFY_CALLBACK_TOKEN: ${{ secrets.NOTIFY_CALLBACK_TOKEN }}
         run: |
           bundle exec cucumber


### PR DESCRIPTION
The dependabot engine can't access secrets in PRs for security reasons.