### PR TITLE
Redirect to the canonical domain

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-APPLICATION_HOST=localhost
+APPLICATION_HOST=southwark-bsp.localhost:3443
 
 # These are fake credentials just formatted correctly so the client accepts them
 NOTIFY_API_KEY=test-f0cf3daf-1e71-4401-9534-955267607d64-a34eb6f8-9fb9-4fb6-9931-ef69bd51cbc1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,21 @@
 class ApplicationController < ActionController::Base
+  before_action :redirect_to_canonical_url, unless: :canonical_domain?
+
+  private
+
+  def canonical_domain
+    ENV.fetch("APPLICATION_HOST") { request.host_with_port }
+  end
+
+  def canonical_domain?
+    canonical_domain == request.host_with_port
+  end
+
+  def canonical_url
+    "#{request.protocol}#{canonical_domain}#{request.fullpath}"
+  end
+
+  def redirect_to_canonical_url
+    redirect_to canonical_url
+  end
 end

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,4 +1,7 @@
 Capybara.server = :puma, { Silent: true }
+Capybara.server_port = 3443
+Capybara.app_host = "http://southwark-bsp.localhost:3443"
+Capybara.default_host = "http://southwark-bsp.localhost"
 
 Capybara.register_driver :chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,4 +23,8 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   Faker::Config.locale = 'en-GB'
+
+  config.before type: :request do
+    host!("southwark-bsp.localhost:3443")
+  end
 end


### PR DESCRIPTION
This is so the 'Open App' button in Heroku works correctly.